### PR TITLE
Fix autorequiring when using different root key forms

### DIFF
--- a/lib/puppet/type/registry_key.rb
+++ b/lib/puppet/type/registry_key.rb
@@ -19,11 +19,6 @@ Puppet::Type.newtype(:registry_key) do
   end
 
   autorequire(:registry_key) do
-    parents = []
-    path = parameter(:path)
-    path.ascend do |hkey, subkey|
-      parents << "#{hkey.keyname}\\#{subkey}" unless subkey == path.subkey # skip ourselves
-    end
-    parents
+    parameter(:path).enum_for(:ascend).select { |p| self[:path] != p }
   end
 end

--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -44,11 +44,7 @@ Puppet::Type.newtype(:registry_value) do
   end
 
   autorequire(:registry_key) do
-    parents = []
-    parameter(:path).ascend do |hkey, subkey|
-      parents << "#{hkey.keyname}\\#{subkey}"
-    end
-    parents
+    parameter(:path).enum_for(:ascend)
   end
 end
 

--- a/lib/puppet/util/value_path.rb
+++ b/lib/puppet/util/value_path.rb
@@ -1,13 +1,11 @@
 require 'puppet/parameter'
-require 'puppet/util/registry_base'
+require 'puppet/util/key_path'
 
 class Puppet::Util::ValuePath < Puppet::Parameter::KeyPath
   attr_reader :valuename
 
-  def split(path)
-    unless path
-      raise ArgumentError, "Invalid registry value"
-    end
+  def munge(path)
+    raise ArgumentError, "Invalid registry value" unless path
 
     if path[-1, 1] == '\\' # trailing backslash implies default value
       super(path.gsub(/\\*$/, ''))
@@ -19,5 +17,8 @@ class Puppet::Util::ValuePath < Puppet::Parameter::KeyPath
       super(path[0, idx])
       @valuename = path[idx+1..-1] if idx > 0
     end
+
+    canonical = subkey.empty? ?  "#{root}\\#{valuename}" : "#{root}\\#{subkey}\\#{valuename}"
+    canonical.downcase
   end
 end

--- a/spec/unit/puppet/type/registry_key_spec.rb
+++ b/spec/unit/puppet/type/registry_key_spec.rb
@@ -26,13 +26,13 @@ describe Puppet::Type.type(:registry_key) do
       end
     end
 
-    %w[unknown unknown\subkey HKEY_PERFORMANCE_DATA].each do |path|
-      it "should reject #{path} as unsupported" do
+    %w[HKEY_DYN_DATA HKEY_PERFORMANCE_DATA].each do |path|
+      it "should reject #{path} as unsupported case insensitively" do
         expect { key[:path] = path }.should raise_error(Puppet::Error, /Unsupported/)
       end
     end
 
-    %[hklm\\ hklm\foo\\].each do |path|
+    %[hklm\\ hklm\foo\\ unknown unknown\subkey].each do |path|
       it "should reject #{path} as invalid" do
         path = "hklm\\" + 'a' * 256
         expect { key[:path] = path }.should raise_error(Puppet::Error, /Invalid registry key/)
@@ -41,7 +41,6 @@ describe Puppet::Type.type(:registry_key) do
 
     %w[HKLM HKEY_LOCAL_MACHINE hklm].each do |root|
       it "should canonicalize the root key #{root}" do
-        pending("Not implemented")
         key[:path] = root
         key[:path].should == 'hklm'
       end


### PR DESCRIPTION
Previously, autorequiring would not add relationships when resources mix
short and long forms of the root key, e.g. hklm and hkey_local_machine. It
also did not handle different cases, hklm vs HKLM.

This commit ensures that we always create a canonical path for the
`KeyPath` and `ValuePath`, which always use the downcased root key name.
In the process, the ascend logic was greatly simplified.

This commit does not fix general case-insensitivity in key and value
names, e.g. so hklm\Software and hklm\software are still seen as different
resources. This will be addressed in a separate commit.
