### PR TITLE
Add the ability to manage 32 and 64-bit keys/values

### DIFF
--- a/lib/puppet/modules/registry/registry_base.rb
+++ b/lib/puppet/modules/registry/registry_base.rb
@@ -24,6 +24,11 @@ module Puppet::Modules::Registry::RegistryBase
   # REG_RESOURCE_LIST REG_FULL_RESOURCE_DESCRIPTOR
   # REG_RESOURCE_REQUIREMENTS_LIST
 
+  # For 64-bit OS, use 64-bit view. Ignored on 32-bit OS
+  KEY_WOW64_64KEY = 0x100
+  # For 64-bit OS, use 32-bit view. Ignored on 32-bit OS
+  KEY_WOW64_32KEY = 0x200
+
   NAME2TYPE = {}
   TYPE2NAME.each_pair {|k,v| NAME2TYPE[v] = k}
 
@@ -37,11 +42,5 @@ module Puppet::Modules::Registry::RegistryBase
 
   def hkeys
     HKEYS
-  end
-
-  def access(mask = 0)
-    # REMIND: skip this if 32-bit OS?
-    #:redirect) == :true ? 0x200 : 0x100)
-    mask | (resource[:redirect] == 'true' ? 0x200 : 0x100)
   end
 end

--- a/lib/puppet/provider/registry_key/registry.rb
+++ b/lib/puppet/provider/registry_key/registry.rb
@@ -18,12 +18,12 @@ Puppet::Type.type(:registry_key).provide(:registry) do
 
   def create
     Puppet.debug("create key #{resource[:path]}")
-    keypath.hkey.create(keypath.subkey, access(Win32::Registry::KEY_ALL_ACCESS)) {|reg| true }
+    keypath.hkey.create(keypath.subkey, Win32::Registry::KEY_ALL_ACCESS | keypath.access) {|reg| true }
   end
 
   def exists?
     Puppet.debug("exists? key #{resource[:path]}")
-    !!keypath.hkey.open(keypath.subkey, access(Win32::Registry::KEY_READ)) {|reg| true } rescue false
+    !!keypath.hkey.open(keypath.subkey, Win32::Registry::KEY_READ | keypath.access) {|reg| true } rescue false
   end
 
   def destroy
@@ -31,7 +31,7 @@ Puppet::Type.type(:registry_key).provide(:registry) do
 
     raise "Cannot delete root key: #{resource[:path]}" unless keypath.subkey
 
-    if RegDeleteKeyEx.call(keypath.hkey.hkey, keypath.subkey, access, 0) != 0
+    if RegDeleteKeyEx.call(keypath.hkey.hkey, keypath.subkey, keypath.access, 0) != 0
       raise "Failed to delete registry key: #{resource[:path]}"
     end
   end

--- a/lib/puppet/provider/registry_value/registry.rb
+++ b/lib/puppet/provider/registry_value/registry.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:registry_value).provide(:registry) do
   def create
     Puppet.info("creating: #{self}")
 
-    valuepath.hkey.open(valuepath.subkey, access(Win32::Registry::KEY_ALL_ACCESS)) do |reg|
+    valuepath.hkey.open(valuepath.subkey, Win32::Registry::KEY_ALL_ACCESS | valuepath.access) do |reg|
       reg.write(valuepath.valuename, name2type(resource[:type]), resource[:data])
     end
   end
@@ -23,7 +23,7 @@ Puppet::Type.type(:registry_value).provide(:registry) do
     Puppet.info("exists: #{self}")
 
     found = false
-    valuepath.hkey.open(valuepath.subkey, access(Win32::Registry::KEY_READ)) do |reg|
+    valuepath.hkey.open(valuepath.subkey, Win32::Registry::KEY_READ | valuepath.access) do |reg|
       type = [0].pack('L')
       size = [0].pack('L')
       found = RegQueryValueExA.call(reg.hkey, valuepath.valuename, 0, type, 0, size) == 0
@@ -36,7 +36,7 @@ Puppet::Type.type(:registry_value).provide(:registry) do
 
     Puppet.info("flushing: #{self}")
 
-    valuepath.hkey.open(valuepath.subkey, access(Win32::Registry::KEY_ALL_ACCESS)) do |reg|
+    valuepath.hkey.open(valuepath.subkey, Win32::Registry::KEY_ALL_ACCESS | valuepath.access) do |reg|
       reg.write(valuepath.valuename, name2type(regvalue[:type]), regvalue[:data])
     end
   end
@@ -44,7 +44,7 @@ Puppet::Type.type(:registry_value).provide(:registry) do
   def destroy
     Puppet.info("destroying: #{self}")
 
-    valuepath.hkey.open(valuepath.subkey, access(Win32::Registry::KEY_ALL_ACCESS)) do |reg|
+    valuepath.hkey.open(valuepath.subkey, Win32::Registry::KEY_ALL_ACCESS | valuepath.access) do |reg|
       reg.delete_value(valuepath.valuename)
     end
   end
@@ -68,7 +68,7 @@ Puppet::Type.type(:registry_value).provide(:registry) do
   def regvalue
     unless @regvalue
       @regvalue = {}
-      valuepath.hkey.open(valuepath.subkey, access(Win32::Registry::KEY_ALL_ACCESS)) do |reg|
+      valuepath.hkey.open(valuepath.subkey, Win32::Registry::KEY_ALL_ACCESS | valuepath.access) do |reg|
         type = [0].pack('L')
         size = [0].pack('L')
 

--- a/lib/puppet/type/registry_key.rb
+++ b/lib/puppet/type/registry_key.rb
@@ -13,11 +13,6 @@ Puppet::Type.newtype(:registry_key) do
   newparam(:path, :parent => Puppet::Modules::Registry::KeyPath, :namevar => true) do
   end
 
-  newparam(:redirect) do
-    newvalues(:true, :false)
-    defaultto :false
-  end
-
   autorequire(:registry_key) do
     parameter(:path).enum_for(:ascend).select { |p| self[:path] != p }
   end

--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -13,11 +13,6 @@ Puppet::Type.newtype(:registry_value) do
   newparam(:path, :parent => Puppet::Modules::Registry::ValuePath, :namevar => true) do
   end
 
-  newparam(:redirect) do
-    newvalues(:true, :false)
-    defaultto :false
-  end
-
   newproperty(:type) do
     newvalues(:string, :array, :dword, :qword, :binary, :expand)
     defaultto :string

--- a/spec/unit/puppet/type/registry_key_spec.rb
+++ b/spec/unit/puppet/type/registry_key_spec.rb
@@ -32,7 +32,7 @@ describe Puppet::Type.type(:registry_key) do
       end
     end
 
-    %[hklm\\ hklm\foo\\ unknown unknown\subkey].each do |path|
+    %[hklm\\ hklm\foo\\ unknown unknown\subkey \:hkey].each do |path|
       it "should reject #{path} as invalid" do
         path = "hklm\\" + 'a' * 256
         expect { key[:path] = path }.should raise_error(Puppet::Error, /Invalid registry key/)
@@ -49,16 +49,10 @@ describe Puppet::Type.type(:registry_key) do
     it 'should be case-preserving'
     it 'should be case-insensitive'
     it 'should autorequire ancestor keys'
-  end
 
-  describe "redirect parameter" do
-    it 'should not redirect by default' do
-      key[:redirect].should == :false
-    end
-
-    it 'should allow redirection' do
-      key[:redirect] = true
-      key[:redirect].should be_true
+    it 'should support 32-bit keys' do
+      key[:path] = '32:hklm\software'
+      key.parameter(:path).access.should == 0x200
     end
   end
 end

--- a/spec/unit/puppet/type/registry_value_spec.rb
+++ b/spec/unit/puppet/type/registry_value_spec.rb
@@ -54,25 +54,15 @@ describe Puppet::Type.type(:registry_value) do
       end
     end
 
-
     it 'should validate the length of the value name'
     it 'should validate the length of the value data'
-    it 'should canonicalize the root key'
     it 'should be case-preserving'
     it 'should be case-insensitive'
     it 'should autorequire ancestor keys'
-  end
 
-  describe "redirect parameter" do
-    let (:value) { described_class.new(:path => 'hklm\software\foo') }
-
-    it 'should not redirect by default' do
-      value[:redirect].should == :false
-    end
-
-    it 'should allow redirection' do
-      value[:redirect] = true
-      value[:redirect].should be_true
+    it 'should support 32-bit values' do
+      value = described_class.new(:path => '32:hklm\software\foo')
+      value.parameter(:path).access.should == 0x200
     end
   end
 


### PR DESCRIPTION
Previously, we were going to support a `redirect` parameter to control on
a per-key and value basis whether to allow or disable registry
redirection. If allowed, then the OS would redirect puppet to the 32-bit
view of the registry. However, since it was a parameter, we could not
manage both the 32 and 64-bit versions of the same key in the same
manifest, due to the paths not being unique. And composite namevars
doesn't help.

This commit removes the redirect parameter and instead allows the key or
value path to be prefixed by `32:`. If specified, the 32-bit view of the
registry is used. If not-specified (default), the 64-bit view of the
registry is used.
