### PR TITLE
Add REG_MULTI_SZ (type => array) imeplementation

### DIFF
--- a/spec/unit/puppet/type/registry_value_spec.rb
+++ b/spec/unit/puppet/type/registry_value_spec.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#!/usr/bin/env ruby -S rspec
 require 'spec_helper'
 require 'puppet/modules/registry/registry_base'
 
@@ -130,7 +130,7 @@ describe Puppet::Type.type(:registry_value) do
     end
 
     context "binary data" do
-      ['', 'CA FE BE EF'].each do |data|
+      ['', 'CA FE BE EF', 'DEADBEEF'].each do |data|
         it "should accept '#{data}'" do
           value[:type] = :binary
           value[:data] = data
@@ -146,8 +146,6 @@ describe Puppet::Type.type(:registry_value) do
     end
 
     context "array data" do
-      pending("array types not implemented")
-
       it "should support array data" do
         value[:type] = :array
         value[:data] = ['foo', 'bar', 'baz']

--- a/tests/registry_examples.pp
+++ b/tests/registry_examples.pp
@@ -63,26 +63,25 @@ class registry_example {
     data   => 'CAFEBEEF',
   }
 
-  # # REVISIT We need to make this work
-  # registry_value { 'HKLM\Software\Vendor\Bar\valuearray1':
-  #   ensure => present,
-  #   type   => array,
-  #   data   => [ 'one', 'two', 'three' ],
-  # }
+  registry_value { 'HKLM\Software\Vendor\Bar\valuearray1':
+    ensure => present,
+    type   => array,
+    data   => [ 'one', 'two', 'three' ],
+  }
 
-  # $some_string = "somestring"
-  # registry_value { 'HKLM\Software\Vendor\Bar\valuearray2':
-  #   ensure => present,
-  #   type   => array,
-  #   data   => [ 'one', 'two', $some_string ],
-  # }
+  $some_string = "somestring"
+  registry_value { 'HKLM\Software\Vendor\Bar\valuearray2':
+    ensure => present,
+    type   => array,
+    data   => [ 0, 'zero', '0', 123456, 'two', $some_string ],
+  }
 
-  # $some_array = [ "array1", "array2", "array3" ]
-  # registry_value { 'HKLM\Software\Vendor\Bar\valuearray3':
-  #   ensure => present,
-  #   type   => array,
-  #   data   => $some_array,
-  # }
+  $some_array = [ "array1", "array2", "array3" ]
+  registry_value { 'HKLM\Software\Vendor\Bar\valuearray3':
+    ensure => present,
+    type   => array,
+    data   => $some_array,
+  }
 }
 
 include registry_example


### PR DESCRIPTION
Without this patch applied the registry type and provider do not have an 
implementation for the following resource declaration.

```
registry_value { 'HKLM\Software\Vendor\Bar\value_array':
 ensure => present,
 type   => array,
 data   => [ 'one', 'two', 'three' ],
```

   }

The `type => array` in the Puppet DSL maps to the REG_MULTI_SZ [1] data type. 
This is basically an ordered list of null terminated strings with two null 
bytes to denote the end of the list.

In Puppet we've implemented this as simply accepting an array for the data 
property.  This implementation also works well with `puppet resource`:

```
PS C:\> puppet resource registry_value HKLM\Software\Vendor\Bar\somearray
```

   registry_value { 'HKLM\Software\Vendor\Bar\somearray':
     ensure => 'present',
     data   => ['one', 'two', 'three'],
     type   => 'array',
   }

[1] http://msdn.microsoft.com/en-us/library/windows/desktop/ms724884.aspx
