### PR TITLE
Allow values associated with a registry key to be purged

### DIFF
--- a/lib/puppet/provider/registry_key/registry.rb
+++ b/lib/puppet/provider/registry_key/registry.rb
@@ -39,4 +39,12 @@ Puppet::Type.type(:registry_key).provide(:registry) do
   def keypath
     @keypath ||= resource.parameter(:path)
   end
+
+  def values
+    names = []
+    keypath.hkey.open(keypath.subkey, Win32::Registry::KEY_READ | keypath.access) do |reg|
+      reg.each_value do |name, type, data| names << name end
+    end
+    names
+  end
 end

--- a/lib/puppet/provider/registry_value/registry.rb
+++ b/lib/puppet/provider/registry_value/registry.rb
@@ -70,7 +70,7 @@ Puppet::Type.type(:registry_value).provide(:registry) do
   def regvalue
     unless @regvalue
       @regvalue = {}
-      valuepath.hkey.open(valuepath.subkey, Win32::Registry::KEY_ALL_ACCESS | valuepath.access) do |reg|
+      valuepath.hkey.open(valuepath.subkey, Win32::Registry::KEY_READ | valuepath.access) do |reg|
         type = [0].pack('L')
         size = [0].pack('L')
 

--- a/lib/puppet/type/registry_key.rb
+++ b/lib/puppet/type/registry_key.rb
@@ -13,6 +13,12 @@ Puppet::Type.newtype(:registry_key) do
   newparam(:path, :parent => Puppet::Modules::Registry::KeyPath, :namevar => true) do
   end
 
+  newparam(:purge, :boolean => true) do
+    desc "Whether to delete any registry value associated with this key that is not being managed by puppet."
+    newvalues(:true, :false)
+    defaultto false
+  end
+
   # Autorequire the nearest ancestor registry_key found in the catalog.
   autorequire(:registry_key) do
     req = []
@@ -20,5 +26,24 @@ Puppet::Type.newtype(:registry_key) do
       req << found.to_s
     end
     req
+  end
+
+  def eval_generate
+    return [] unless value(:purge)
+
+    # get the "should" names of registry values associated with this key
+    should_values = catalog.relationship_graph.direct_dependents_of(self).select {|dep| dep.type == :registry_value }.map do |reg|
+      reg.parameter(:path).valuename
+    end
+
+    # get the "is" names of registry values associated with this key
+    is_values = provider.values
+
+    # create absent registry_value resources for the complement
+    resources = []
+    (is_values - should_values).each do |name|
+      resources << Puppet::Type.type(:registry_value).new(:path => "#{self[:path]}\\#{name}", :ensure => :absent)
+    end
+    resources
   end
 end


### PR DESCRIPTION
Previously, puppet could only manage registry values as a 'minimal' set,
but not as an 'inclusive' set.

This commit adds a `purge` parameter to the registry_key type. If set to
true, puppet will purge all registry values associated with the key that
are not being managed by puppet. For example, if a key `foo` contains
values `bar`, `baz`, and puppet is only managing `baz` and `qux`, then
`bar` would be purged (deleted).

  registry_key { 'hklm\software\foo':
    ensure => present,
    purge  => true
  }
  registry_value { 'hklm\software\baz':
    ensure => present,
    type   => string,
    data   => 'val1'
  }
  registry_value { 'hklm\software\qux':
    ensure => present,
    type   => string,
    data   => 'val2'
  }

This commit satisfies the use-case where the user wants to specify the
exact set of values for a key and ensure that no other values exist
(without having to know what their names might be).
