### PR TITLE
Work around #3947, #4248, #14073; load our utility code

### DIFF
--- a/lib/puppet/modules/registry.rb
+++ b/lib/puppet/modules/registry.rb
@@ -1,4 +1,12 @@
-require 'puppet/modules'
+require 'pathname'
+# JJM WORK_AROUND
+# explicitly require files without relying on $LOAD_PATH until #14073 is fixed.
+# https://projects.puppetlabs.com/issues/14073 is fixed.
+require Pathname.new(__FILE__).dirname.expand_path
 
 module Puppet::Modules::Registry
+  # For 64-bit OS, use 64-bit view. Ignored on 32-bit OS
+  KEY_WOW64_64KEY = 0x100 unless defined? KEY_WOW64_64KEY
+  # For 64-bit OS, use 32-bit view. Ignored on 32-bit OS
+  KEY_WOW64_32KEY = 0x200 unless defined? KEY_WOW64_32KEY
 end

--- a/lib/puppet/modules/registry/registry_base.rb
+++ b/lib/puppet/modules/registry/registry_base.rb
@@ -1,46 +1,49 @@
-require 'puppet/modules/registry'
+require 'pathname' # JJM WORK_AROUND #14073
+require Pathname.new(__FILE__).dirname.expand_path
 
 module Puppet::Modules::Registry::RegistryBase
-  require 'win32/registry'
-
-  HKEYS = {
-    :hkcr => Win32::Registry::HKEY_CLASSES_ROOT,
-    :hklm => Win32::Registry::HKEY_LOCAL_MACHINE,
-    #:hku  => Win32::Registry::HKEY_USERS,
-    #:hkcu => HKEY_CURRENT_USER,
-  }
-
-  TYPE2NAME = {
-    Win32::Registry::REG_NONE => :none,
-    Win32::Registry::REG_SZ   => :string,
-    Win32::Registry::REG_EXPAND_SZ => :expand,
-    Win32::Registry::REG_BINARY => :binary,
-    Win32::Registry::REG_DWORD => :dword,
-    Win32::Registry::REG_QWORD => :qword,
-    Win32::Registry::REG_MULTI_SZ => :array
-  }
+  if Puppet.features.microsoft_windows?
+    begin
+      require 'win32/registry'
+    rescue LoadError => exc
+      msg = "Could not load the required win32/registry library (ErrorID 1EAD86E3-D533-4286-BFCB-CCE8B818DDEA) [#{exc.message}]"
+      Puppet.err msg
+      error = Puppet::Error.new(msg)
+      error.set_backtrace exc.backtrace
+      raise error
+    end
+  end
 
   # REG_DWORD_BIG_ENDIAN REG_LINK
   # REG_RESOURCE_LIST REG_FULL_RESOURCE_DESCRIPTOR
   # REG_RESOURCE_REQUIREMENTS_LIST
 
-  # For 64-bit OS, use 64-bit view. Ignored on 32-bit OS
-  KEY_WOW64_64KEY = 0x100
-  # For 64-bit OS, use 32-bit view. Ignored on 32-bit OS
-  KEY_WOW64_32KEY = 0x200
-
-  NAME2TYPE = {}
-  TYPE2NAME.each_pair {|k,v| NAME2TYPE[v] = k}
+  def type2name_map
+    {
+      Win32::Registry::REG_NONE      => :none,
+      Win32::Registry::REG_SZ        => :string,
+      Win32::Registry::REG_EXPAND_SZ => :expand,
+      Win32::Registry::REG_BINARY    => :binary,
+      Win32::Registry::REG_DWORD     => :dword,
+      Win32::Registry::REG_QWORD     => :qword,
+      Win32::Registry::REG_MULTI_SZ  => :array
+    }
+  end
 
   def type2name(type)
-    return TYPE2NAME[type]
+    type2name_map[type]
   end
 
   def name2type(name)
-    return NAME2TYPE[name]
+    name2type = {}
+    type2name_map.each_pair {|k,v| name2type[v] = k}
+    name2type[name]
   end
 
   def hkeys
-    HKEYS
+    {
+      :hkcr => Win32::Registry::HKEY_CLASSES_ROOT,
+      :hklm => Win32::Registry::HKEY_LOCAL_MACHINE,
+    }
   end
 end

--- a/lib/puppet/modules/registry/value_path.rb
+++ b/lib/puppet/modules/registry/value_path.rb
@@ -1,5 +1,9 @@
+require 'pathname'
+# JJM WORK_AROUND
+# explicitly require files without relying on $LOAD_PATH until #14073 is fixed.
+# https://projects.puppetlabs.com/issues/14073 is fixed.
+require Pathname.new(__FILE__).dirname.expand_path + 'key_path'
 require 'puppet/parameter'
-require 'puppet/modules/registry/key_path'
 
 class Puppet::Modules::Registry::ValuePath < Puppet::Modules::Registry::KeyPath
   attr_reader :valuename

--- a/lib/puppet/type/registry_key.rb
+++ b/lib/puppet/type/registry_key.rb
@@ -1,7 +1,8 @@
-require 'puppet/modules/registry/registry_base'
-require 'puppet/modules/registry/key_path'
-
+require 'puppet/type'
 Puppet::Type.newtype(:registry_key) do
+  require 'pathname' # JJM WORK_AROUND #14073
+  require Pathname.new(__FILE__).dirname.dirname.expand_path + 'modules/registry/registry_base'
+  require Pathname.new(__FILE__).dirname.dirname.expand_path + 'modules/registry/key_path'
   include Puppet::Modules::Registry::RegistryBase
 
   def self.title_patterns

--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -1,7 +1,8 @@
-require 'puppet/modules/registry/registry_base'
-require 'puppet/modules/registry/value_path'
-
+require 'puppet/type'
 Puppet::Type.newtype(:registry_value) do
+  require 'pathname' # JJM WORK_AROUND #14073
+  require Pathname.new(__FILE__).dirname.dirname.expand_path + 'modules/registry/registry_base'
+  require Pathname.new(__FILE__).dirname.dirname.expand_path + 'modules/registry/value_path'
   include Puppet::Modules::Registry::RegistryBase
 
   def self.title_patterns


### PR DESCRIPTION
Without this patch the registry module blows up when installed onto a
Linux Puppet Master.  The utility code and the structure of the types
and providers end up requiring win32/registry which will never be
present on non-windows systems.  In addition, the types and providers
mix in module level support code, which does not work because of the
following Puppet bugs, all related to our inability to load utility code
from the $LOAD_PATH.
- https://projects.puppetlabs.com/issues/3947
- https://projects.puppetlabs.com/issues/4248
- https://projects.puppetlabs.com/issues/14073

This has annoyed me enough that I'm going revisit these bugs and the
interplay of the modulepath, environments, and $LOAD_PATH.
