### PR TITLE
Allow values associated with a registry key to be purged

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,6 +18,43 @@ The `registry_key` and `registry_value` types are provided by this module.
       data   => "The Puppet Agent service periodically manages your configuration",
     }
 
+If you want to make sure only the values specified in Puppet are associated
+with a particular key, you can use the `purge_values => true` parameter of the
+`registry_key` resource to delete any values not explicitly managed by Puppet.
+The `registry::example_purge` class shows how this is accomplished:
+
+Make sure the `registry::example_purge` class is included in the node catalog,
+then setup a registry key that contains six values:
+
+    PS C:\> $env:FACTER_PURGE_EXAMPLE_MODE = 'setup'
+    PS C:\> puppet agent --test
+    notice: /Stage[main]/Registry::Purge_example/Registry_key[HKLM\Software\Vendor\Puppet Labs\Examples\KeyPurge]/ensure: created
+    notice: /Stage[main]/Registry::Purge_example/Registry_value[HKLM\Software\Vendor\Puppet Labs\Examples\KeyPurge\Value3]/ensure: created
+    notice: /Stage[main]/Registry::Purge_example/Registry_value[HKLM\Software\Vendor\Puppet Labs\Examples\KeyPurge\Value2]/ensure: created
+    notice: /Stage[main]/Registry::Purge_example/Registry_key[HKLM\Software\Vendor\Puppet Labs\Examples\KeyPurge\SubKey]/ensure: created
+    notice: /Stage[main]/Registry::Purge_example/Registry_value[HKLM\Software\Vendor\Puppet Labs\Examples\KeyPurge\Value5]/ensure: created
+    notice: /Stage[main]/Registry::Purge_example/Registry_value[HKLM\Software\Vendor\Puppet Labs\Examples\KeyPurge\Value6]/ensure: created
+    notice: /Stage[main]/Registry::Purge_example/Registry_value[HKLM\Software\Vendor\Puppet Labs\Examples\KeyPurge\SubKey\Value1]/ensure: created
+    notice: /Stage[main]/Registry::Purge_example/Registry_value[HKLM\Software\Vendor\Puppet Labs\Examples\KeyPurge\Value1]/ensure: created
+    notice: /Stage[main]/Registry::Purge_example/Registry_value[HKLM\Software\Vendor\Puppet Labs\Examples\KeyPurge\SubKey\Value2]/ensure: created
+    notice: /Stage[main]/Registry::Purge_example/Registry_value[HKLM\Software\Vendor\Puppet Labs\Examples\KeyPurge\Value4]/ensure: created
+    notice: Finished catalog run in 0.14 seconds
+
+Switching the mode to 'purge' will cause the class to only manage three of the
+six `registry_value` resources.  The other three will be purged since the
+`registry_key` resource has `purge_values => true` specified in the manifest.
+Notice how Value4, Value5 and Value6 are being removed.
+
+    PS C:\> $env:FACTER_PURGE_EXAMPLE_MODE = 'purge'
+    PS C:\> puppet agent --test
+    notice: /Registry_value[hklm\Software\Vendor\Puppet Labs\Examples\KeyPurge\Value4]/ensure: removed
+    notice: /Registry_value[hklm\Software\Vendor\Puppet Labs\Examples\KeyPurge\Value6]/ensure: removed
+    notice: /Registry_value[hklm\Software\Vendor\Puppet Labs\Examples\KeyPurge\Value5]/ensure: removed
+    notice: /Stage[main]/Registry::Purge_example/Registry_value[HKLM\Software\Vendor\Puppet Labs\Examples\KeyPurge\Value3]/data: data changed 'key3' to 'should not be purged'
+    notice: /Stage[main]/Registry::Purge_example/Registry_value[HKLM\Software\Vendor\Puppet Labs\Examples\KeyPurge\Value2]/data: data changed '2' to '0'
+    notice: /Stage[main]/Registry::Purge_example/Registry_value[HKLM\Software\Vendor\Puppet Labs\Examples\KeyPurge\Value1]/data: data changed '1' to '0'
+    notice: Finished catalog run in 0.16 seconds
+
 Installation
 ------------
 

--- a/lib/puppet/provider/registry_key/registry.rb
+++ b/lib/puppet/provider/registry_key/registry.rb
@@ -38,4 +38,15 @@ Puppet::Type.type(:registry_key).provide(:registry) do
   def keypath
     @keypath ||= resource.parameter(:path)
   end
+
+  def values
+    names = []
+    # Only try and get the values for this key if the key itself exists.
+    if exists? then
+      keypath.hkey.open(keypath.subkey, Win32::Registry::KEY_READ | keypath.access) do |reg|
+        reg.each_value do |name, type, data| names << name end
+      end
+    end
+    names
+  end
 end

--- a/lib/puppet/provider/registry_value/registry.rb
+++ b/lib/puppet/provider/registry_value/registry.rb
@@ -67,7 +67,7 @@ Puppet::Type.type(:registry_value).provide(:registry) do
   def regvalue
     unless @regvalue
       @regvalue = {}
-      valuepath.hkey.open(valuepath.subkey, Win32::Registry::KEY_ALL_ACCESS | valuepath.access) do |reg|
+      valuepath.hkey.open(valuepath.subkey, Win32::Registry::KEY_READ | valuepath.access) do |reg|
         type = [0].pack('L')
         size = [0].pack('L')
 

--- a/lib/puppet/type/registry_key.rb
+++ b/lib/puppet/type/registry_key.rb
@@ -3,7 +3,7 @@ Puppet::Type.newtype(:registry_key) do
   require 'pathname' # JJM WORK_AROUND #14073
   require Pathname.new(__FILE__).dirname.dirname.expand_path + 'modules/registry/registry_base'
   require Pathname.new(__FILE__).dirname.dirname.expand_path + 'modules/registry/key_path'
-  include Puppet::Modules::Registry::RegistryBase
+  extend Puppet::Modules::Registry::RegistryBase
 
   def self.title_patterns
     [ [ /^(.*?)\Z/m, [ [ :path, lambda{|x| x} ] ] ] ]
@@ -14,6 +14,32 @@ Puppet::Type.newtype(:registry_key) do
   newparam(:path, :parent => Puppet::Modules::Registry::KeyPath, :namevar => true) do
   end
 
+  newparam(:purge_values, :boolean => true) do
+    desc "Whether to delete any registry value associated with this key that is not being managed by puppet."
+    newvalues(:true, :false)
+    defaultto false
+
+    validate do |value|
+      case value
+      when true, /^true$/i, :true, false, /^false$/i, :false, :undef, nil
+        true
+      else
+        # We raise an ArgumentError and not a Puppet::Error so we get manifest
+        # and line numbers in the error message displayed to the user.
+        raise ArgumentError.new("Validation Error: purge_values must be true or false, not #{value}")
+      end
+    end
+
+    munge do |value|
+      case value
+      when true, /^true$/i, :true
+        true
+      else
+        false
+      end
+    end
+  end
+
   # Autorequire the nearest ancestor registry_key found in the catalog.
   autorequire(:registry_key) do
     req = []
@@ -21,5 +47,25 @@ Puppet::Type.newtype(:registry_key) do
       req << found.to_s
     end
     req
+  end
+
+  def eval_generate
+    # This value will be given post-munge so we can assume it will be a ruby true or false object
+    return [] unless value(:purge_values)
+
+    # get the "should" names of registry values associated with this key
+    should_values = catalog.relationship_graph.direct_dependents_of(self).select {|dep| dep.type == :registry_value }.map do |reg|
+      reg.parameter(:path).valuename
+    end
+
+    # get the "is" names of registry values associated with this key
+    is_values = provider.values
+
+    # create absent registry_value resources for the complement
+    resources = []
+    (is_values - should_values).each do |name|
+      resources << Puppet::Type.type(:registry_value).new(:path => "#{self[:path]}\\#{name}", :ensure => :absent)
+    end
+    resources
   end
 end

--- a/manifests/purge_example.pp
+++ b/manifests/purge_example.pp
@@ -1,0 +1,118 @@
+# = Class: registry::purge_example
+#
+#   This class provides an example of how to purge registry values associated
+#   with a specific key.
+#
+#   This class has two modes of operation determined by the Facter fact
+#   PURGE_EXAMPLE_MODE  The value of this fact can be either 'setup' or 'purge'
+#
+#   The easiest way to set this mode is to set an environment variable in Power Shell:
+#
+#   The setup mode creates a registry key and 6 values.
+#
+#   `$env:FACTER_PURGE_EXAMPLE_MODE = "setup"`
+#   `puppet agent --test`
+#
+#   The purge mode manages the key with purge_values => true and manages only 3
+#   of the 6 values.  The other 3 values will be automatically purged.
+#
+#   `$env:FACTER_PURGE_EXAMPLE_MODE = "purge"`
+#   `puppet agent --test`
+#
+# = Parameters
+#
+# = Actions
+#
+# = Requires
+#
+# = Sample Usage
+#
+#   include registry::purge_example
+#
+# (MARKUP: http://links.puppetlabs.com/puppet_manifest_documentation)
+class registry::purge_example {
+
+  $key_path = 'HKLM\Software\Vendor\Puppet Labs\Examples\KeyPurge'
+
+  case $::purge_example_mode {
+    setup: {
+      registry_key { $key_path:
+        ensure       => present,
+        purge_values => false,
+      }
+      registry_key { "${key_path}\\SubKey":
+        ensure       => present,
+        purge_values => false,
+      }
+      registry_value { "${key_path}\\SubKey\\Value1":
+        ensure => present,
+        type   => dword,
+        data   => 1,
+      }
+      registry_value { "${key_path}\\SubKey\\Value2":
+        ensure => present,
+        type   => dword,
+        data   => 1,
+      }
+      registry_value { "${key_path}\\Value1":
+        ensure => present,
+        type   => dword,
+        data   => 1,
+      }
+      registry_value { "${key_path}\\Value2":
+        ensure => present,
+        type   => dword,
+        data   => 2,
+      }
+      registry_value { "${key_path}\\Value3":
+        ensure => present,
+        type   => string,
+        data   => 'key3',
+      }
+      registry_value { "${key_path}\\Value4":
+        ensure => present,
+        type   => array,
+        data   => [ 'one', 'two', 'three' ],
+      }
+      registry_value { "${key_path}\\Value5":
+        ensure => present,
+        type   => expand,
+        data   => '%SystemRoot%\system32',
+      }
+      registry_value { "${key_path}\\Value6":
+        ensure => present,
+        type   => binary,
+        data   => '01AB CDEF',
+      }
+    }
+    purge: {
+      registry_key { $key_path:
+        ensure       => present,
+        purge_values => true,
+      }
+      registry_value { "${key_path}\\Value1":
+        ensure => present,
+        type   => dword,
+        data   => 0,
+      }
+      registry_value { "${key_path}\\Value2":
+        ensure => present,
+        type   => dword,
+        data   => 0,
+      }
+      registry_value { "${key_path}\\Value3":
+        ensure => present,
+        type   => string,
+        data   => 'should not be purged',
+      }
+    }
+    default: {
+      notify { "purge_example_notice":
+        message => "The purge_example_mode fact is not set.  To try this
+        example class first set \$env:FACTER_PURGE_EXAMPLE_MODE = 'setup' then
+        run puppet agent, then set \$env:FACTER_PURGE_EXAMPLE_MODE = 'purge'
+        and run puppet agent again to see the values purged.",
+      }
+    }
+  }
+}

--- a/spec/unit/puppet/type/registry_key_spec.rb
+++ b/spec/unit/puppet/type/registry_key_spec.rb
@@ -1,5 +1,7 @@
 #!/usr/bin/env rspec
 require 'spec_helper'
+require 'puppet/resource'
+require 'puppet/resource/catalog'
 require 'puppet/modules/registry/registry_base'
 
 describe Puppet::Type.type(:registry_key) do
@@ -17,7 +19,7 @@ describe Puppet::Type.type(:registry_key) do
 
   describe "path parameter" do
     it "should have a path parameter" do
-      Puppet::Type.type(:registry_key).attrtype(:path).should == :param
+      Puppet::Type.type(:registry_key).attrtype(:path).must == :param
     end
 
     %w[hklm hklm\software hklm\software\vendor].each do |path|
@@ -42,7 +44,7 @@ describe Puppet::Type.type(:registry_key) do
     %w[HKLM HKEY_LOCAL_MACHINE hklm].each do |root|
       it "should canonicalize the root key #{root}" do
         key[:path] = root
-        key[:path].should == 'hklm'
+        key[:path].must == 'hklm'
       end
     end
 
@@ -52,7 +54,44 @@ describe Puppet::Type.type(:registry_key) do
 
     it 'should support 32-bit keys' do
       key[:path] = '32:hklm\software'
-      key.parameter(:path).access.should == 0x200
+      key.parameter(:path).access.must == 0x200
+    end
+  end
+
+  describe "#eval_generate" do
+    context "not purging" do
+      it "should return an empty array" do
+        key.eval_generate.must be_empty
+      end
+    end
+
+    context "purging" do
+      let (:catalog) do Puppet::Resource::Catalog.new end
+
+      before :each do
+        key[:purge_values] = true
+        catalog.add_resource(key)
+        catalog.add_resource(Puppet::Type.type(:registry_value).new(:path => "#{key[:path]}\\val1"))
+        catalog.add_resource(Puppet::Type.type(:registry_value).new(:path => "#{key[:path]}\\val2"))
+      end
+
+      it "should return an empty array if the key doesn't have any values" do
+        key.provider.expects(:values).returns([])
+        key.eval_generate.must be_empty
+      end
+
+      it "should purge existing values that are not being managed" do
+        key.provider.expects(:values).returns(['val1', 'val3'])
+        res = key.eval_generate.first
+
+        res[:ensure].must == :absent
+        res[:path].must == "#{key[:path]}\\val3"
+      end
+
+      it "should return an empty array if all existing values are being managed" do
+        key.provider.expects(:values).returns(['val1', 'val2'])
+        key.eval_generate.must be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, puppet could only manage registry values as a 'minimal' set,
but not as an 'inclusive' set.

This commit adds a `purge_values` parameter to the registry_key type. If
set to true, puppet will purge all registry values associated with the
key that are not being managed by puppet. For example, if a key `foo`
contains values `bar`, `baz`, and puppet is only managing `baz` and
`qux`, then `bar` would be purged (deleted).

This patch does not purge registry keys that are children of a registry
key resource being managed.  It only purges values.

  registry_key { 'hklm\software\foo':
    ensure       => present,
    purge_values => true
  }
  registry_value { 'hklm\software\baz':
    ensure => present,
    type   => string,
    data   => 'val1'
  }
  registry_value { 'hklm\software\qux':
    ensure => present,
    type   => string,
    data   => 'val2'
  }

This commit satisfies the use-case where the user wants to specify the
exact set of values for a key and ensure that no other values exist
(without having to know what their names might be).

Add registry::purge_example class

This patch adds a class to the registry module to make it easier for the
user to see the behavior of the purge_values registry_key property.

The user needs to include the registry::purge_example class in the node
catalog, then set the following environment variables:

```
PS C:\> $env:FACTER_PURGE_EXAMPLE_MODE = 'setup'
PS C:\> puppet agent --test
```

This command will configure a registry key with a sub key and values
associated with the key.

```
PS C:\> $env:FACTER_PURGE_EXAMPLE_MODE = 'purge'
PS C:\> puppet agent --test
```

This command will configure a registry key with purge_values => true and
manage only half of the registry_value resources managed in the setup
phase.
