### PR TITLE
(Maint) Fix unhandled exception working around #4248

### DIFF
--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -1,7 +1,8 @@
 require 'puppet/type'
 begin
+  debugger
   require "puppet_x/puppetlabs/registry"
-rescue
+rescue LoadError => detail
   require 'pathname' # JJM WORK_AROUND #14073 and #7788
   require Pathname.new(__FILE__).dirname + "../../" + "puppet_x/puppetlabs/registry"
 end


### PR DESCRIPTION
Without this patch applied the Puppet master will error out because of an
uncaught exception trying to load utility code.  This is a problem because
the registry types and providers cause catalog compilation to fail.

The root cause of this problem is that require without an exception class
will default to a behavior that does not catch LoadError exceptions.

This patch fixes the problem by explicitly catching LoadError and re-raising
if the work-around fails.
