### PR TITLE
Update spec_helper for rspec 2.x

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,9 @@
 dir = File.expand_path(File.dirname(__FILE__))
 $LOAD_PATH.unshift File.join(dir, 'lib')
 
-require 'mocha'
 require 'puppet'
-require 'rspec'
+gem 'rspec', '>=2.0.0'
+require 'rspec/expectations'
 
 RSpec.configure do |config|
     config.mock_with :mocha


### PR DESCRIPTION
Without this patch the spec_helper.rb does not load things correctly to
run these tests with rspec 2.x and mocha.

This patch changes the require statements to load 'rspec' and
'rspec/expectations' correctly.
