### PR TITLE
Refactor class variable usage in registry_value

### DIFF
--- a/lib/puppet/provider/registry_value/registry.rb
+++ b/lib/puppet/provider/registry_value/registry.rb
@@ -140,7 +140,11 @@ Puppet::Type.type(:registry_value).provide(:registry) do
   end
 
   def reg_query_value_ex_a
-    @@reg_query_value_ex_a ||= Win32API.new('advapi32', 'RegQueryValueEx', 'LPLPPP', 'L')
+    self.class.reg_query_value_ex_a
+  end
+
+  def self.reg_query_value_ex_a
+    @reg_query_value_ex_a ||= Win32API.new('advapi32', 'RegQueryValueEx', 'LPLPPP', 'L')
   end
 
   private


### PR DESCRIPTION
Without this commit the provider for the registry_value type was using a
class instance variable. The purpose of this variable was to share a
single instance of a `Win32API` object between all provider instances.
The method of accessing this shared object from the provider instances
was to call the class variable with '@@' prepended. Starting with Ruby 1.9,
use of this method is considered harmful and now causes a warning to be rasied.

This commit adds an accessor class method to replace accessing the class
instance variable directly. The call that originally accessed the class
variable has been refactored to use the accessor method of the class.
