### PR TITLE
Add travis support and update specs for rspec 2.14

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,5 @@
+fixtures:
+  repositories:
+    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+  symlinks:
+    registry: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ pkg/
 .DS_Store
 metadata.json
 coverage/
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: ruby
+bundler_args: --without development
+script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+env:
+  matrix:
+    - PUPPET_GEM_VERSION="~> 2.7.0"
+    - PUPPET_GEM_VERSION="~> 3.0.0"
+    - PUPPET_GEM_VERSION="~> 3.1.0"
+    - PUPPET_GEM_VERSION="~> 3.2.0"
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 2.7.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 2.7.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.0.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,16 @@
+source 'https://rubygems.org'
+
+group :development, :test do
+  gem 'rake',                    :require => false
+  gem 'rspec-puppet',            :require => false
+  gem 'puppetlabs_spec_helper',  :require => false
+  gem 'puppet-lint',             :require => false
+end
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end
+
+# vim:ft=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,16 +1,1 @@
-require 'rake'
-require 'rspec/core/rake_task'
-
-task :default => [:test]
-
-desc 'Run RSpec'
-RSpec::Core::RakeTask.new(:test) do |t|
-  t.pattern = 'spec/{unit}/**/*.rb'
-#  t.rspec_opts = ['--color']
-end
-
-desc 'Generate code coverage'
-RSpec::Core::RakeTask.new(:coverage) do |t|
-  t.rcov = true
-  t.rcov_opts = ['--exclude', 'spec']
-end
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,8 @@
-dir = File.expand_path(File.dirname(__FILE__))
-$LOAD_PATH.unshift File.join(dir, 'lib')
-
-require 'mocha'
-require 'puppet'
-require 'rspec'
+require 'puppetlabs_spec_helper/module_spec_helper'
 
 RSpec.configure do |config|
-    config.mock_with :mocha
-end
-
-# We need this because the RAL uses 'should' as a method.  This
-# allows us the same behaviour but with a different method name.
-class Object
-    alias :must :should
+  config.tty = true
+  config.mock_with :rspec do |c|
+    c.syntax = :expect
+  end
 end


### PR DESCRIPTION
This adds travis support, adds bundler, adds the puppetlabs_spec_helper rake tasks and spec stuff, and updates the specs for rspec 2.14.
