### PR TITLE
Revert "Merge pull request #27 from hunner/release_0.1.2"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,19 +1,3 @@
-2013-08-01 Release 0.1.2
-Summary:
-This is a bugfix release that allows the module to work more reliably on x64
-systems and on older systems such as 2003. Also fixes compilation errors due
-to windows library loading on *nix masters.
-
-Bugfixes:
-- Fixed specs against newer rspec and added travis
-- Refactored code into PuppetX namespace
-- Fixed unhandled exception when loading windows code on *nix
-- Updated README and manifest documentation
-- Only manage redirected keys on 64 bit systems
-- Only use /sysnative filesystem when available
-- Use class accessor method instead of class instance variable
-- Add geppetto project file
-
 0.1.1 - 2012-05-21 - Jeff McCune <jeff@puppetlabs.com>
  * (#14517) Improve error handling when writing values (27223db)
  * (#14572) Fix management of the default value (f29bdc5)

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-registry'
-version '0.1.2'
+version '0.1.1'
 source 'git://github.com/puppetlabs/puppetlabs-registry.git'
 author 'puppetlabs'
 license 'Apache License, Version 2.0'


### PR DESCRIPTION
This 0.1.2 release was erroneous. Backing out.

This reverts commit e8c82f72a0580564b14263c7d440597d21ee3a3e, reversing
changes made to cfc0b5225323731af76fd8b4f7c9bcfc66004c70.
