### PR TITLE
FM-103: Add metadata.json to all modules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 pkg/
 .DS_Store
-metadata.json
 coverage/

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,25 @@
+{
+    "name": "puppetlabs/registry",
+    "version": "0.1.2",
+    "summary": "This module provides a native type and provider to manage keys and values in the Windows Registry",
+    "source": "git@github.com/puppetlabs/puppetlabs-registry.git",
+    "project_page": "http://github.com/puppetlabs/puppetlabs-registry",
+    "author": "Puppet Labs",
+    "license": "Apache-2.0",
+    "operatingsystem_support": [
+        "Windows"
+    ],
+    "puppet_version": [
+        2.7,
+        3.0,
+        3.1,
+        3.2,
+        3.3
+    ],
+    "dependencies": [
+        {
+            "name": "puppetlabs/stdlib",
+            "version_requirement": ">= 2.3.0"
+        }
+    ]
+}


### PR DESCRIPTION
This is part of some work around supported modules, ensuring we can accurately reflect what Puppet versions and Operating systems we support on the forge.
