### PR TITLE
(MODULES-1292) Don't try to apply a regex to a binary string

### DIFF
--- a/lib/puppet/provider/registry_value/registry.rb
+++ b/lib/puppet/provider/registry_value/registry.rb
@@ -126,7 +126,7 @@ Puppet::Type.type(:registry_value).provide(:registry) do
     pdata =
       case type2name(ntype)
       when :binary
-        ndata.scan(/./).map{ |byte| byte.unpack('H2')[0]}.join(' ')
+        ndata.bytes.map{ |byte| "%02x" % byte }.join(' ')
       when :array
         # We get the data from the registry in Array form.
         ndata

--- a/spec/unit/puppet/provider/registry_value_spec.rb
+++ b/spec/unit/puppet/provider/registry_value_spec.rb
@@ -25,5 +25,17 @@ describe Puppet::Type.type(:registry_value).provider(:registry), :if => Puppet.f
       reg_value.provider.data.should eq ['System']
       reg_value.provider.type.should eq :string
     end
+
+    it "returns a string of lowercased hex encoded bytes" do
+      reg = described_class.new
+      type, data = reg.from_native([3, "\u07AD"])
+      data.should eq ['de ad']
+    end
+
+    it "left pads binary strings" do
+      reg = described_class.new
+      type, data = reg.from_native([3, "\x1"])
+      data.should eq ['01']
+    end
   end
 end


### PR DESCRIPTION
Previously, if you used the registry module with ruby 2 (either x86 or x64)
to manage a binary string with value 'de ad', it would correctly write the
value to the registry, but everytime puppet ran afterward, it would incorrectly
read the "current" value as 'de', losing the 'ad' part.

The root cause is because the registry modules was calling String#scan on
a binary string. In ruby 1.9, the string encoding is based on the current
code page, e.g. cp1252.

```
irb(main):006:0> ndata = [0xde, 0xad].pack('C*')
=> "\xDE\xAD"
irb(main):007:0> ndata.force_encoding('cp1252')
=> "\xDE\xAD"
irb(main):008:0> ndata.scan(/./)
=> ["\xDE", "\xAD"]
```

But in ruby 2, the default encoding is UTF-8, and the two byte sequence is
interpreted as a two byte character:

```
irb(main):002:0> ndata = [0xde, 0xad].pack('C*')
=> "\xDE\xAD"
irb(main):003:0> ndata.force_encoding('UTF-8')
=> "\u07AD"
irb(main):004:0> ndata.scan(/./)
=> ["\u07AD"]
```

Ruby's registry code should be setting the binary string encoding to
ASCII-8BIT, but does not.

This commit changes the provider to convert the string to bytes, and then
formats each byte as a lowercase hex string. This works regardless of what
encoding ruby is currently using.
