### PR TITLE
Remove duplicate dependency on puppetlabs/stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -37,10 +37,6 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 2.3.0"
-    },
-    {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.3.0"
     }
   ]
 }


### PR DESCRIPTION
See: https://tickets.puppetlabs.com/browse/GEP-194 for an issue caused
by the redundant dependency.
