### PR TITLE
(maint) Multiple node acceptance fixes

### DIFF
--- a/acceptance/setup/install_pe.rb
+++ b/acceptance/setup/install_pe.rb
@@ -11,7 +11,7 @@ test_name "Installing Puppet Enterprise" do
       %w(lib manifests metadata.json).each do |file|
         scp_to host, "#{proj_root}/#{file}", target
       end
-      on host, shell('curl -k -o c:/puppetlabs-stdlib-4.5.1.tar.gz https://forgeapi.puppetlabs.com/v3/files/puppetlabs-stdlib-4.5.1.tar.gz')
+      on host, 'curl -k -o c:/puppetlabs-stdlib-4.5.1.tar.gz https://forgeapi.puppetlabs.com/v3/files/puppetlabs-stdlib-4.5.1.tar.gz'
       on host, puppet('module install c:/puppetlabs-stdlib-4.5.1.tar.gz --force --ignore-dependencies'), {:acceptable_exit_codes => [0, 1]}
     end
   end

--- a/acceptance/setup/install_puppet.rb
+++ b/acceptance/setup/install_puppet.rb
@@ -17,7 +17,7 @@ test_name "Installing Puppet" do
       %w(lib manifests metadata.json).each do |file|
         scp_to host, "#{proj_root}/#{file}", target
       end
-      on host, shell('curl -k -o c:/puppetlabs-stdlib-4.5.1.tar.gz https://forgeapi.puppetlabs.com/v3/files/puppetlabs-stdlib-4.5.1.tar.gz')
+      on host, 'curl -k -o c:/puppetlabs-stdlib-4.5.1.tar.gz https://forgeapi.puppetlabs.com/v3/files/puppetlabs-stdlib-4.5.1.tar.gz'
       on host, puppet('module install c:/puppetlabs-stdlib-4.5.1.tar.gz --force --ignore-dependencies'), {:acceptable_exit_codes => [0, 1]}
     end
   end

--- a/acceptance/tests/resource/registry/should_manage_values.rb
+++ b/acceptance/tests/resource/registry/should_manage_values.rb
@@ -203,7 +203,7 @@ end
 
 step "Start testing should_manage_values" do
   windows_agents.each do |agent|
-    x64 = x64?(default)
+    x64 = x64?(agent)
 
     # A set of keys we expect Puppet to create
     phase1_resources_created = [
@@ -212,7 +212,7 @@ step "Start testing should_manage_values" do
         /Registry_key\[HKLM.Software.Vendor.PuppetLabsTest\w+\\SubKey2\].ensure: created/,
     ]
 
-    if x64?(agent)
+    if x64
       phase1_resources_created += [
           /Registry_key\[32:HKLM.Software.Vendor.PuppetLabsTest\w+\].ensure: created/,
           /Registry_key\[32:HKLM.Software.Vendor.PuppetLabsTest\w+\\SubKey1\].ensure: created/,


### PR DESCRIPTION
 - Beakers shell function always uses the default node, which is
   undesirable for installing stdlib
 - The x64? check in should_manage_values should be using the bitness
   of the node under test, not the default node