### PR TITLE
(maint) add AppVeyor support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+version: 1.1.x.{build}
+skip_commits:
+  message: /(^\(?doc\)?.*|.*[A|a]cceptance [T|t]est.*)/
+clone_depth: 10
+init:
+- SET
+- 'mkdir C:\ProgramData\PuppetLabs\code && exit 0'
+- 'mkdir C:\ProgramData\PuppetLabs\facter && exit 0'
+- 'mkdir C:\ProgramData\PuppetLabs\hiera && exit 0'
+- 'mkdir C:\ProgramData\PuppetLabs\puppet\var && exit 0'
+environment:
+  matrix:
+  - PUPPET_GEM_VERSION: ~> 4.0
+    RUBY_VER: 21
+  - PUPPET_GEM_VERSION: ~> 4.0
+    RUBY_VER: 21-x64
+  - PUPPET_GEM_VERSION: ~> 3.0
+    RUBY_VER: 193
+  - PUPPET_GEM_VERSION: ~> 3.0
+    RUBY_VER: 200-x64
+  - PUPPET_GEM_VERSION: 3.3.2
+    RUBY_VER: 193
+matrix:
+  fast_finish: true
+install:
+- SET PATH=C:\Ruby%RUBY_VER%\bin;%PATH%
+- gem install bundler --quiet --no-ri --no-rdoc
+- bundle install --jobs 4 --retry 2 --without development system_tests
+- type Gemfile.lock
+build: off
+test_script:
+- bundle exec puppet -V
+- ruby -v
+- bundle exec rspec spec/unit -fd -b
+notifications:
+- provider: Email
+  to:
+  - nobody@nowhere.com
+  on_build_success: false
+  on_build_failure: false
+  on_build_status_changed: false
+


### PR DESCRIPTION
 - Setup a matrix with:
    - Ruby 2.1 and Puppet 4.x (latest) and
    - Ruby 2.0 x64 / Ruby 1.9.3 x86 + Puppet 3.x (latest)
    - Ruby 1.9.3 x86 + Puppet 3.3.2 (oldest supported)


This has some content from #82 that should be removed when that PR is rebased / updated. //cc @cyberious 