### PR TITLE
(maint) fix registry_value provider spec fail

### DIFF
--- a/spec/unit/puppet/provider/registry_value_spec.rb
+++ b/spec/unit/puppet/provider/registry_value_spec.rb
@@ -60,8 +60,8 @@ describe Puppet::Type.type(:registry_value).provider(:registry), :if => Puppet.f
 
   describe "#regvalue" do
     it "should return a valid string for a well known key" do
-      reg_value = type.new(:path => 'hklm\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SoftwareType', :provider => described_class.name)
-      reg_value.provider.data.should eq ['System']
+      reg_value = type.new(:path => 'hklm\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SystemRoot', :provider => described_class.name)
+      reg_value.provider.data.should eq [ENV['SystemRoot']]
       reg_value.provider.type.should eq :string
     end
 


### PR DESCRIPTION
 - As it turns out, the previous test for a well known value
   would fail under Windows 2003, because the value is SYSTEM
   instead of System.  We could adjust the case, but instead
   perform a match of a given key to an environment variable
   that should match it to rule out OS specific casing issues.