### PR TITLE
(maint) add environment info to acceptance tests

### DIFF
--- a/acceptance/.beaker-git.cfg
+++ b/acceptance/.beaker-git.cfg
@@ -2,7 +2,7 @@
     :load_path  => "./acceptance/lib/",
     :hosts_file     => './acceptance/config/windows-2012-x86_64.cfg',
     :type       => "foss",
-    :pre_suite  => ["./acceptance/setup/install_puppet.rb"],
+    :pre_suite  => ['./acceptance/setup/install_puppet.rb', './acceptance/setup/environment_info.rb'],
     :tests      => "./acceptance/tests",
     :log_level  => "debug",
     :timeout    => 6000,

--- a/acceptance/.beaker-pe.cfg
+++ b/acceptance/.beaker-pe.cfg
@@ -2,7 +2,7 @@
     :load_path  => "./acceptance/lib/",
     :hosts_file     => './acceptance/config/windows-2012-x86_64.cfg',
     :type       => "pe",
-    :pre_suite  => ['./acceptance/setup/install_puppet.rb'],
+    :pre_suite  => ['./acceptance/setup/install_puppet.rb', './acceptance/setup/environment_info.rb'],
     :tests      => "./acceptance/tests/",
     :log_level  => "debug",
     :timeout    => 6000,

--- a/acceptance/setup/environment_info.rb
+++ b/acceptance/setup/environment_info.rb
@@ -1,0 +1,10 @@
+test_name "Expose Environment Information" do
+  hosts.each do |host|
+    if host['platform'] =~ /windows/
+      on host, shell('cmd /c SET', { :accept_all_exit_codes => true })
+      on host, shell('cmd /c puppet -V', { :accept_all_exit_codes => true })
+      on host, shell('cmd /c facter -v', { :accept_all_exit_codes => true })
+      on host, shell('cmd /c facter', { :accept_all_exit_codes => true })
+    end
+  end
+end


### PR DESCRIPTION
Report on environment information so we know what we expected is
installed during the setup phase.