### PR TITLE
(MODULES-2409) Endian-ness incorrect for DWORD and QWORD

### DIFF
--- a/spec/unit/puppet/provider/registry_value_spec.rb
+++ b/spec/unit/puppet/provider/registry_value_spec.rb
@@ -30,6 +30,9 @@ describe Puppet::Type.type(:registry_value).provider(:registry), :if => Puppet.f
       # also, expect that we're not using Rubys each_key / each_value which exhibit bad behavior
       Win32::Registry.any_instance.expects(:each_key).never
       Win32::Registry.any_instance.expects(:each_value).never
+
+      # this covers []= write_s write_i and write_bin
+      Win32::Registry.any_instance.expects(:write).never
     end
   end
 


### PR DESCRIPTION
 - In 0b99718bc7 a helper method to_byte_array was introduced to convert
   a numeric value into a properly padded byte array.  Unfortunately
   that introduced an error as the byte array ordering was incorrect.

   This has caused DWORD and QWORD values to be written wrong.

   For instance, creating a native (little) endian string from a large
   32-bit value (4294967294) should yield the following bytes:

   pry(main)> [2**32-2].pack('L').unpack('C*')
   => [254, 255, 255, 255]

   That can be further round-tripped with .pack('C*').unpack('L*')[0]

   However, using to_bytes_array, the bytes come back improperly ordered

   pry(main)> to_byte_array(2**32-2, 4)
   => [255, 255, 255, 254]

   pry(main)> [255, 255, 255, 254].pack('C*').unpack('L*')[0]
   => 4278190079

   As a result, because of the improper ordering of bytes, the wrong
   value is written.

 - Previous tests were passing since the range of written values
   tested was below 0xFF (255).  The first point at which written
   values diverge is 256, where the byte array [0, 1, 0, 0] should
   have been created, but instead [1, 0, 0, 0] was written.

 - The simplest additional test to perform was to validate that the
   written values from the deletion test match what is expected.