### PR TITLE
(FM-4917) Rake / Beaker / Rspec compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 pkg/
 Gemfile.lock
 Gemfile.local
-vendor/
 spec/fixtures/
 log/
 junit/

--- a/.sync.yml
+++ b/.sync.yml
@@ -6,20 +6,6 @@
     env: PUPPET_GEM_VERSION="3.3.0"
 Gemfile:
   supports_windows: true
-  required:
-    ':development':
-      - gem: rake
-      - gem: rspec
-        version: '~>2.14.1'
-      - gem: puppet-lint
-      - gem: puppetlabs_spec_helper
-        version: '~>0.10.3'
-      - gem: puppet_facts
-      - gem: mocha
-        version: '~>0.10.5'
-    ':system_tests':
-      - gem: beaker
-      - gem: beaker-puppet_install_helper
 Rakefile:
   unmanaged: true
 spec/spec_helper.rb:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,5 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="3.3.0"
-  allow_failures:
-    - rvm: 2.1.5
-      env: PUPPET_GEM_VERSION="~> 4.0"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -25,16 +25,28 @@ def location_for(place_or_version, fake_version = nil)
   end
 end
 
+# The following gems are not included by default as they require DevKit on Windows.
+# You should probably include them in a Gemfile.local or a ~/.gemfile
+#gem 'pry' #this may already be included in the gemfile
+#gem 'pry-stack_explorer', :require => false
+#if RUBY_VERSION =~ /^2/
+#  gem 'pry-byebug'
+#else
+#  gem 'pry-debugger'
+#end
+
 group :development do
   gem 'rake',                                :require => false
-  gem 'rspec', '~>2.14.1',                   :require => false
+  gem 'rspec', '~>3.0',                      :require => false
   gem 'puppet-lint',                         :require => false
   gem 'puppetlabs_spec_helper', '~>0.10.3',  :require => false
   gem 'puppet_facts',                        :require => false
   gem 'mocha', '~>0.10.5',                   :require => false
+  gem 'pry',                                 :require => false
 end
 
 group :system_tests do
+  gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '~> 5.1')
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.20')
   gem 'beaker-puppet_install_helper',  :require => false
 end
@@ -107,8 +119,14 @@ if explicitly_require_windows_gems
   gem "windows-pr",  "1.2.3",           :require => false
 end
 
+# Evaluate Gemfile.local if it exists
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
+end
+
+# Evaluate ~/.gemfile if it exists
+if File.exists?(File.join(Dir.home, '.gemfile'))
+  eval(File.read(File.join(Dir.home, '.gemfile')), binding)
 end
 
 # vim:ft=ruby

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,6 @@ matrix:
   fast_finish: true
 install:
 - SET PATH=C:\Ruby%RUBY_VER%\bin;%PATH%
-- gem install bundler --quiet --no-ri --no-rdoc
 - bundle install --jobs 4 --retry 2 --without system_tests
 - type Gemfile.lock
 build: off

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,10 @@ RSpec.configure do |c|
     c.error_stream = $stderr
     c.formatters.each { |f| f.instance_variable_set(:@output, $stdout) }
   end
+
+  c.expect_with :rspec do |e|
+    e.syntax = [:should, :expect]
+  end
 end
 
 # We need this because the RAL uses 'should' as a method.  This

--- a/spec/unit/puppet/provider/registry_key_spec.rb
+++ b/spec/unit/puppet/provider/registry_key_spec.rb
@@ -33,17 +33,17 @@ describe Puppet::Type.type(:registry_key).provider(:registry), :if => Puppet.fea
       guid = SecureRandom.uuid
       reg_key = type.new(:path => "hklm\\#{puppet_key}\\#{subkey_name}\\#{guid}", :provider => described_class.name)
       already_exists = reg_key.provider.exists?
-      already_exists.should be_false
+      already_exists.should be_falsey
 
       # something has gone terribly wrong here, pull the ripcord
       break if already_exists
 
       reg_key.provider.create
-      reg_key.provider.exists?.should be_true
+      reg_key.provider.exists?.should be true
 
       # test FFI code
       reg_key.provider.destroy
-      reg_key.provider.exists?.should be_false
+      reg_key.provider.exists?.should be false
     end
   end
 
@@ -59,7 +59,7 @@ describe Puppet::Type.type(:registry_key).provider(:registry), :if => Puppet.fea
       reg_key = type.new(:path => "hklm\\#{reg_path}", :provider => described_class.name)
       reg_key.provider.destroy
 
-      reg_key.provider.exists?.should be_false
+      reg_key.provider.exists?.should be_falsey
     end
 
     context "with ANSI strings on all Ruby platforms" do

--- a/spec/unit/puppet/provider/registry_value_spec.rb
+++ b/spec/unit/puppet/provider/registry_value_spec.rb
@@ -52,12 +52,12 @@ describe Puppet::Type.type(:registry_value).provider(:registry), :if => Puppet.f
   describe "#exists?" do
     it "should return true for a well known hive" do
       reg_value = type.new(:path => 'hklm\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SoftwareType', :provider => described_class.name)
-      reg_value.provider.exists?.should be_true
+      reg_value.provider.exists?.should be true
     end
 
     it "should return false for a bogus hive/path" do
       reg_value = type.new(:path => 'hklm\foobar5000', :catalog => catalog, :provider => described_class.name)
-      reg_value.provider.exists?.should be_false
+      reg_value.provider.exists?.should be false
     end
   end
 
@@ -89,17 +89,17 @@ describe Puppet::Type.type(:registry_value).provider(:registry), :if => Puppet.f
         :data => data,
         :provider => described_class.name)
       already_exists = reg_value.provider.exists?
-      already_exists.should be_false
+      already_exists.should be_falsey
 
       # something has gone terribly wrong here, pull the ripcord
       fail if already_exists
 
       reg_value.provider.create
-      reg_value.provider.exists?.should be_true
+      reg_value.provider.exists?.should be true
       expect(reg_value.provider.data).to eq([data].flatten)
 
       reg_value.provider.destroy
-      reg_value.provider.exists?.should be_false
+      reg_value.provider.exists?.should be false
     end
 
     it "can destroy a randomly created REG_SZ value" do
@@ -185,7 +185,7 @@ describe Puppet::Type.type(:registry_value).provider(:registry), :if => Puppet.f
         :provider => described_class.name)
 
       reg_value.provider.destroy
-      reg_value.provider.exists?.should be_false
+      reg_value.provider.exists?.should be_falsey
     end
 
     # proof that there is no conversion to local encodings like IBM437
@@ -206,10 +206,10 @@ describe Puppet::Type.type(:registry_value).provider(:registry), :if => Puppet.f
         :provider => described_class.name)
 
       already_exists = reg_value.provider.exists?
-      already_exists.should be_false
+      already_exists.should be_falsey
 
       reg_value.provider.create
-      reg_value.provider.exists?.should be_true
+      reg_value.provider.exists?.should be true
 
       reg_value.provider.data.length.should eq 1
       reg_value.provider.type.should eq :string

--- a/spec/unit/puppet/type/registry_key_spec.rb
+++ b/spec/unit/puppet/type/registry_key_spec.rb
@@ -7,10 +7,16 @@ require 'puppet/type/registry_key'
 describe Puppet::Type.type(:registry_key) do
   let (:catalog) do Puppet::Resource::Catalog.new end
 
+
   # This is overridden here so we get a consistent association with the key
   # and a catalog using memoized let methods.
   let (:key) do
     Puppet::Type.type(:registry_key).new(:name => 'HKLM\Software', :catalog => catalog)
+  end
+  let(:provider) { Puppet::Provider.new(key) }
+
+  before :each do
+    key.provider = provider
   end
 
   [:ensure].each do |property|


### PR DESCRIPTION
Beaker needs a version of Rake less than 11 due to using
`last_comment' in rake_task.rb:62. Reduce the version of
Rake down to the same dependency that Beaker does as a
development dependency.

Rspec 3+ requires that should be explicitly set as an expect term.
be_true and be_false have also been changed so that they are not
whether something is truthy or falsey, but simply really true/false. To
get the older behavior, the test simply needs to check for be_truthy or
be_falsey. For explicit true/false checks, it is be true and be false.

Remove gem install bundler as part of modulesync updates.

Paired with Glenn Sarti <glenn.sarti at puppetlabs dot com>