### PR TITLE
(maint) Fix the style of the registry::value parameters

### DIFF
--- a/manifests/value.pp
+++ b/manifests/value.pp
@@ -39,7 +39,13 @@
 #     }
 #   }
 #
-define registry::value($key, $value=undef, $type='string', $data=undef) {
+define registry::value (
+  $key,
+  $value = undef,
+  $type  = 'string',
+  $data  = undef,
+) {
+
   # ensure windows os
   if $::operatingsystem != 'windows'{
     fail("Unsupported OS ${::operatingsystem}")


### PR DESCRIPTION
Prior to this, the parameters in the defined type, registry::value, were
all on one line and not spaced according to the Puppet Labs style guide.

This commit fixes that by putting each parameter on its own line and
lining everything up.