### PR TITLE
(MODULES-4446) Modify README and update the registry_value type

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
-#registry
+# registry
 [![Build Status](https://travis-ci.org/puppetlabs/puppetlabs-registry.png?branch=master)](https://travis-ci.org/puppetlabs/puppetlabs-registry)
 
-####Table of Contents
+#### Table of Contents
 
 1. [Overview - What is the registry module?](#overview)
 2. [Module Description - What registry does and why it is useful](#module-description)
@@ -15,19 +15,19 @@
 6. [Limitations](#limitations)
 7. [Development - Guide for contributing to registry](#development)
 
-##Overview
+## Overview
 
 This module supplies the types and providers you'll need to manage the Registry on your Windows nodes.
 
-##Module Description
+## Module Description
 
 The Registry is a hierarchical database built into Microsoft Windows. It stores settings and other information for the operating system and a wide range of applications. This module lets Puppet manage individual Registry keys and values, and provides a simplified way to manage Windows services.
 
-##Setup
+## Setup
 
 This module must be installed on your Puppet master. We've tested it with Puppet agents running on Windows Server 2003, 2008 R2, 2012, and 2012 R2.
 
-###Beginning with registry
+### Beginning with registry
 
 Use the `registry_key` type to manage a single registry key:
 
@@ -35,11 +35,11 @@ Use the `registry_key` type to manage a single registry key:
       ensure => present,
     }
 
-##Usage
+## Usage
 
 The registry module works mainly through two types: `registry_key` and `registry_value`. These types combine to let you specify a Registry container and its intended contents.
 
-###Manage a single Registry value
+### Manage a single Registry value
 
     registry_value { 'HKLM\System\CurrentControlSet\Services\Puppet\Description':
       ensure => present,
@@ -47,7 +47,7 @@ The registry module works mainly through two types: `registry_key` and `registry
       data   => "The Puppet Agent service periodically manages your configuration",
     }
 
-###Manage a Registry value and its parent key in one declaration
+### Manage a Registry value and its parent key in one declaration
 
     class myapp {
       registry::value { 'puppetmaster':
@@ -62,7 +62,7 @@ Puppet looks up the key 'HKLM\Software\Vendor\PuppetLabs' and makes sure it cont
 
 Within this define, you can specify multiple Registry values for one Registry key and manage them all at once.
 
-###Set the default value for a key
+### Set the default value for a key
 
     registry::value { 'Setting0':
       key   => 'HKLM\System\CurrentControlSet\Services\Puppet',
@@ -73,7 +73,7 @@ Within this define, you can specify multiple Registry values for one Registry ke
 You can still add values in a string (or array) beyond the default, but you can only set one default value per key.
 
 
-###Purge existing values
+### Purge existing values
 
 By default, if a key includes additional values besides the ones you specify through this module, Puppet leaves those extra values in place. To change that, use the `purge_values => true` parameter of the `registry_key` resource. **Enabling this feature deletes any values in the key that are not managed by Puppet.**
 
@@ -110,7 +110,7 @@ Notice how Value4, Value5 and Value6 are being removed.
     notice: /Stage[main]/Registry::Purge_example/Registry_value[HKLM\Software\Vendor\Puppet Labs\Examples\KeyPurge\Value1]/data: data changed '1' to '0'
     notice: Finished catalog run in 0.16 seconds
 
-###Manage Windows services
+### Manage Windows services
 
 The `registry::service` define manages entries in the Microsoft service control framework by automatically manipulating values in the key HKLM\System\CurrentControlSet\Services\$name\.
 
@@ -123,106 +123,106 @@ This is an alternative approach to using INSTSRV.EXE [1](http://support.microsof
       command      => 'C:\PuppetLabs\Puppet\service\daemon.bat',
     }
 
-##Reference
+## Reference
 
-###Public Defines
+### Public Defines
 * `registry::value`: Manages the parent key for a particular value. If the parent key doesn't exist, Puppet automatically creates it.
 * `registry::service`: Manages entries in the Microsoft service control framework by manipulating values in the key HKLM\System\CurrentControlSet\Services\$name\.
 
-###Public Types
+### Public Types
 * `registry_key`: Manages individual Registry keys.
 * `registry_value`: Manages individual Registry values.
 
-###Parameters
+### Parameters
 
-####`registry::value`:
+#### `registry::value`:
 
-#####`key`
+##### `key`
 
-*Required.* Specifies a Registry key for Puppet to manage. If any of the parent keys in the path don't exist, Puppet creates them automatically. Valid options: a string containing a Registry path.
+*Required.* Specifies a Registry key for Puppet to manage. Note that if any of the parent keys in the path do not exist, the resource raises an error. Use the `registry_key` to create the parent key prior to setting a registry value. Valid options: a string containing a Registry path.
 
-#####`data`
+##### `data`
 
 *Required.* Provides the contents of the specified value. Valid options: a string by default; an array if specified through the `type` parameter.
 
-#####`type`
+##### `type`
 
 *Optional.* Sets the data type of the specified value. Valid options: 'string', 'array', 'dword', 'qword', 'binary', and 'expand'. Default value: 'string'.
 
-#####`value`
+##### `value`
 
 *Optional.* Determines what Registry value(s) to manage within the specified key. To set a Registry value as the default value for its parent key, name the value '(default)'. Valid options: a string. Default value: the title of your declared resource.
 
-####`registry_key`
+#### `registry_key`
 
-#####`ensure`
+##### `ensure`
 
 Tells Puppet whether the key should or shouldn't exist. Valid options: 'present' and 'absent'. Default value: 'present'.
 
-#####`path`
+##### `path`
 
 *Required.* Specifies a Registry key for Puppet to manage. If any of the parent keys in the path don't exist, Puppet creates them automatically. Valid options: a string containing a Registry path. For example: 'HKLM\Software' or 'HKEY_LOCAL_MACHINE\Software\Vendor'.
 
 If Puppet is running on a 64-bit system, the 32-bit Registry key can be explicitly managed using a prefix. For example: '32:HKLM\Software'.
 
-#####`purge_values`
+##### `purge_values`
 
 *Optional.* Specifies whether to delete any values in the specified key that are not managed by Puppet. Valid options: 'true' and 'false'. Default value: 'false'.
 
 For more on this parameter, see the [Purge existing values section](#purge-existing-values) under Usage.
 
-####`registry_value`
+#### `registry_value`
 
-#####`path`
+##### `path`
 
 *Optional.* Specifies a Registry value for Puppet to manage. Valid options: a string containing a Registry path. If any of the parent keys in the path don't exist, Puppet creates them automatically. For example: 'HKLM\Software' or 'HKEY_LOCAL_MACHINE\Software\Vendor'. Default value: the title of your declared resource.
 
 If Puppet is running on a 64-bit system, the 32-bit Registry key can be explicitly managed using a prefix. For example: '32:HKLM\Software\Value3'.
 
-#####`ensure`
+##### `ensure`
 
 Tells Puppet whether the value should or shouldn't exist. Valid options: 'present' and 'absent'. Default value: 'present'.
 
-#####`type`
+##### `type`
 
 *Optional.* Sets the data type of the specified value. Valid options: 'string', 'array', 'dword', 'qword', 'binary', and 'expand'. Default value: 'string'.
 
-#####`data`
+##### `data`
 
 *Required.* Provides the contents of the specified value. Valid options: a string by default; an array if specified through the `type` parameter.
 
-####`registry::service`
+#### `registry::service`
 
-#####`ensure`
+##### `ensure`
 
 Tells Puppet whether the service should or shouldn't exist. Valid options: 'present' and 'absent'. Default value: 'present'.
 
-#####`display_name`
+##### `display_name`
 
 *Optional.* Provides a Display Name for the service. Valid options: a string. Default value: the title of your declared resource.
 
-#####`description`
+##### `description`
 
 *Optional.* Provides a description of the service. Valid options: a string. Default value: blank.
 
-#####`command`
+##### `command`
 
 *Required.* Specifies the command to execute when starting the service. Valid options: a string containing the absolute path to an executable file.
 
-#####`start`
+##### `start`
 
 *Required.* Specifies the starting mode of the service. Valid options: 'automatic', 'manual', and 'disabled'.
 
 Puppet's [native service resource](http://docs.puppet.com/references/latest/type.html#service) can also be used to manage this setting.
 
-##Limitations
+## Limitations
 
 * Keys within HKEY_LOCAL_MACHINE (hklm), HKEY_CLASSES_ROOT (hkcr) or HKEY_USERS (hku) are supported. Other predefined root keys (e.g., HKEY_CURRENT_USER) are not currently supported.
 * Puppet doesn't recursively delete Registry keys.
 
 Please report any issues through our [Module Issue Tracker](https://tickets.puppet.com/browse/MODULES).
 
-##Development
+## Development
 
 Puppet Inc modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can't access the huge number of platforms and myriad of hardware, software, and deployment configurations that Puppet is intended to serve.
 
@@ -230,6 +230,6 @@ We want to keep it as easy as possible to contribute changes so that our modules
 
 For more information, see our [module contribution guide.](https://docs.puppet.com/forge/contributing.html)
 
-###Contributors
+### Contributors
 
 To see who's already involved, see the [list of contributors.](https://github.com/puppetlabs/puppetlabs-registry/graphs/contributors)


### PR DESCRIPTION
Previously the registry_value type stated that it created parent keys
if they did not exist, however this is not true.  This commit updates the text
to indicate that if the parent keys do not exist an error will raised, and a
recommendation to use the registry_key to ensure the parent keys exist first.

This commit also reformats the markdown so that there is a single space between
the header hashes and the text as per Puppet markdown guidelines.

[skip ci]