### PR TITLE
(MODULES-4976) Remove rspec configuration for win32_console

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,13 +11,6 @@ require 'puppetlabs_spec_helper/module_spec_helper'
 RSpec.configure do |c|
   c.mock_with :mocha
 
-  if File::ALT_SEPARATOR && RUBY_VERSION =~ /^1\./
-    require 'win32console'
-    c.output_stream = $stdout
-    c.error_stream = $stderr
-    c.formatters.each { |f| f.instance_variable_set(:@output, $stdout) }
-  end
-
   c.expect_with :rspec do |e|
     e.syntax = [:should, :expect]
   end


### PR DESCRIPTION
Previously the spec_helper would configure rspec to output all to STDOUT due to
issues with the win32_console gem.  However as that gem was removed in Puppet 4,
it is no longer required.  Also by redirecting to stdout, when using the junit
formatter, the output is sent to STDOUT instead of the specificed text file.
This commit removes the redundant rpsec configuration.