### PR TITLE
(MODULES-5157) Constrain stdlib dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.3.0"
+      "version_requirement": ">= 2.3.0 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
This commit constrains the stdlib dependency so that it is not open ended anymore