### PR TITLE
{WIP}(MODULES-2957) Allow backslashes in registry value names

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,4 +1,4 @@
 fixtures:
   symlinks:
     registry: "#{source_dir}"
-    mixed_default_settings: "#{source_dir}/spec/fixtures/mixed_default_settings"
+    test_registry: "#{source_dir}/spec/fixtures/test_registry"

--- a/lib/puppet/provider/registry_value/registry.rb
+++ b/lib/puppet/provider/registry_value/registry.rb
@@ -28,7 +28,6 @@ Puppet::Type.type(:registry_value).provide(:registry) do
           status = RegQueryValueExW(reg.hkey, valuename_ptr,
             FFI::MemoryPointer::NULL, FFI::MemoryPointer::NULL,
             FFI::MemoryPointer::NULL, FFI::MemoryPointer::NULL)
-
           found = status == 0
           raise Win32::Registry::Error.new(status) if !found
         end
@@ -89,6 +88,10 @@ Puppet::Type.type(:registry_value).provide(:registry) do
 
   def data=(value)
     regvalue[:data] = value
+  end
+
+  def valuename
+    @valuename ||= resource.parameter(:value_name).value
   end
 
   def regvalue

--- a/lib/puppet/type/registry_key.rb
+++ b/lib/puppet/type/registry_key.rb
@@ -106,17 +106,19 @@ EOT
                       .relationship_graph
                       .direct_dependents_of(self)
                       .select {|dep| dep.type == :registry_value }
-                      .map { |reg| reg.parameter(:value_name).value }
+                      .map { |reg| reg.parameter(:value_name).value.downcase }
 
     # get the "is" names of registry values associated with this key
     is_values = provider.values
 
     # create absent registry_value resources for the complement
     resources = []
-    (is_values - should_values).each do |name|
-      # Registry values have a separate Path and Value Name, so just generate a unique title
-      title = "RemoveRegValue#{SecureRandom.uuid}"
-      resources << Puppet::Type.type(:registry_value).new(:title => title, :path => self[:path], :value_name => name, :ensure => :absent, :catalog => catalog)
+    is_values.each do |is_value|
+      unless should_values.include?(is_value.downcase)
+        # Registry values have a separate Path and Value Name, so just generate a unique title
+        title = "Generated_#{self[:path]}\\#{is_value}_#{SecureRandom.uuid}"
+        resources << Puppet::Type.type(:registry_value).new(:title => title, :path => self[:path], :value_name => is_value, :ensure => :absent, :catalog => catalog)
+      end
     end
     resources
   end

--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -132,6 +132,16 @@ Puppet::Type.newtype(:registry_value) do
     end
   end
 
+  # Need to override the normal name method due to PUP-8620
+  # https://tickets.puppetlabs.com/browse/PUP-8260
+  # The registry_key eval_generate method creates regitry_value resources, however
+  # as this is a compound namevar resource it "breaks" (sends nil) the name which
+  # is used the eval_generate method to uniquely identify resources.  Instead we
+  # just return the title ourselves
+  def name
+    self.title
+  end
+
   # Autorequire the nearest ancestor registry_key found in the catalog.
   autorequire(:registry_key) do
     # This is a value path and not a key path because it's based on the path of

--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -17,9 +17,22 @@ Puppet::Type.newtype(:registry_value) do
     **Autorequires:** Any parent registry key managed by Puppet will be
     autorequired.
   EOT
-
   def self.title_patterns
-    [[/^(.*?)\Z/m, [[:path, lambda { |x| x }]]]]
+    [
+      [
+        /^(.+)\\(.*)$/,
+        [
+          [:path],
+          [:value_name],
+        ]
+      ],
+      [
+        /^([^\\]+)$/,
+        [
+          [:path],
+        ]
+      ]
+    ]
   end
 
   ensurable
@@ -36,18 +49,16 @@ Puppet::Type.newtype(:registry_value) do
     end
     munge do |path|
       reg_path = PuppetX::Puppetlabs::Registry::RegistryValuePath.new(path)
-      # Windows is case insensitive and case preserving.  We deal with this by
-      # aliasing resources to their downcase values.  This is inspired by the
-      # munge block in the alias metaparameter.
-      if @resource.catalog
-        reg_path.aliases.each do |alt_name|
-          @resource.catalog.alias(@resource, alt_name)
-        end
-      else
-        Puppet.debug "Resource has no associated catalog.  Aliases are not being set for #{@resource.to_s}"
-      end
       reg_path.canonical
     end
+  end
+
+  newparam(:value_name, :namevar => true) do
+    desc "The name of the registry value to manage.  For example:
+      'Value1' or 'Value\1'. This is typically specified
+      separately when the value name includes backslashes. A value of empty
+      string, for example '' denotes the default value of the registry key path
+      will be managed"
   end
 
   newproperty(:type) do
@@ -123,16 +134,13 @@ Puppet::Type.newtype(:registry_value) do
 
   # Autorequire the nearest ancestor registry_key found in the catalog.
   autorequire(:registry_key) do
-    req = []
     # This is a value path and not a key path because it's based on the path of
     # the value resource.
     path = PuppetX::Puppetlabs::Registry::RegistryValuePath.new(value(:path))
     # It is important to match against the downcase value of the path because
     # other resources are expected to alias themselves to the downcase value so
     # that we respect the case insensitive and preserving nature of Windows.
-    if found = path.enum_for(:ascend).find { |p| catalog.resource(:registry_key, p.to_s.downcase) }
-      req << found.to_s.downcase
-    end
-    req
+    found = path.enum_for(:ascend_with_self).find { |p| catalog.resource(:registry_key, p.to_s.downcase) }
+    found.nil? ? [] : [found.to_s.downcase]
   end
 end

--- a/lib/puppet_x/puppetlabs/registry/provider_base.rb
+++ b/lib/puppet_x/puppetlabs/registry/provider_base.rb
@@ -182,10 +182,6 @@ module ProviderBase
     path.subkey
   end
 
-  def valuename
-    path.valuename
-  end
-
   def type2name_map
     {
       Win32::Registry::REG_NONE      => :none,

--- a/manifests/value.pp
+++ b/manifests/value.pp
@@ -76,8 +76,10 @@ define registry::value (
   # If value_real is an empty string then the default value of the key will be
   # managed.
   registry_value { "${key}\\${value_real}":
-    type => $type,
-    data => $data,
+    path       => $key,
+    value_name => $value_real,
+    type       => $type,
+    data       => $data,
   }
 }
 

--- a/spec/acceptance/should_create_key_spec.rb
+++ b/spec/acceptance/should_create_key_spec.rb
@@ -18,20 +18,20 @@ describe 'Registry Key Management' do
       registry_key { 'HKLM\\Software\\Vendor': ensure => present }
       Registry_key { ensure => present }
       Registry_value { ensure => present, data => 'Puppet Default Data' }
-    
+
       registry_key { '#{keypath}': }
       registry_key { '#{keypath}\\SubKey1': }
-    
+
       if $architecture == 'x64' {
         registry_key { '32:#{keypath}': }
         registry_key { '32:#{keypath}\\SubKey1': }
       }
-    
+
       registry_key   { '#{keypath}\\SubKeyToPurge': }
       registry_value { '#{keypath}\\SubKeyToPurge\\Value1': }
       registry_value { '#{keypath}\\SubKeyToPurge\\Value2': }
       registry_value { '#{keypath}\\SubKeyToPurge\\Value3': }
-    
+
       if $architecture == 'x64' {
         registry_key   { '32:#{keypath}\\SubKeyToPurge': }
         registry_value { '32:#{keypath}\\SubKeyToPurge\\Value1': }
@@ -44,7 +44,7 @@ PHASE1
     phase2 = <<PHASE2
       registry_key { 'HKLM\\Software\\Vendor': ensure => present }
       Registry_key { ensure => present, purge_values => true }
-    
+
       registry_key { '#{keypath}\\SubKeyToPurge': }
       if $architecture == 'x64' {
         registry_key { '32:#{keypath}\\SubKeyToPurge': }
@@ -55,7 +55,7 @@ PHASE2
     phase3 = <<PHASE3
       registry_key { 'HKLM\\Software\\Vendor': ensure => present }
       Registry_key { ensure => absent }
-    
+
       # These have relationships because autorequire break things when
       # ensure is absent.  REVISIT: Make this not a requirement.
       # REVISIT: This appears to work with explicit relationships but not with ->
@@ -65,7 +65,7 @@ PHASE2
       registry_key { '#{keypath}':
         require => Registry_key['#{keypath}\\SubKeyToPurge', '#{keypath}\\SubKey1'],
       }
-    
+
       if $architecture == 'x64' {
         registry_key { '32:#{keypath}\\SubKey1': }
         registry_key { '32:#{keypath}\\SubKeyToPurge': }
@@ -90,15 +90,15 @@ PHASE3
 
     # A set of regular expression of values to be purged in phase 2.
     values_purged_native = [
-        /Registry_value\[hklm.Software.Vendor.PuppetLabsTest\w+.SubKeyToPurge.Value1\].ensure: removed/,
-        /Registry_value\[hklm.Software.Vendor.PuppetLabsTest\w+.SubKeyToPurge.Value2\].ensure: removed/,
-        /Registry_value\[hklm.Software.Vendor.PuppetLabsTest\w+.SubKeyToPurge.Value3\].ensure: removed/
+        /Registry_value\[Generated_hklm\\Software\\Vendor\\PuppetLabsTest\w+.SubKeyToPurge\\Value1_[\w-]+\].ensure: removed/,
+        /Registry_value\[Generated_hklm\\Software\\Vendor\\PuppetLabsTest\w+.SubKeyToPurge\\Value2_[\w-]+\].ensure: removed/,
+        /Registry_value\[Generated_hklm\\Software\\Vendor\\PuppetLabsTest\w+.SubKeyToPurge\\Value3_[\w-]+\].ensure: removed/
     ]
 
     values_purged_wow = [
-        /Registry_value\[32:hklm.Software.Vendor.PuppetLabsTest\w+.SubKeyToPurge.Value1\].ensure: removed/,
-        /Registry_value\[32:hklm.Software.Vendor.PuppetLabsTest\w+.SubKeyToPurge.Value2\].ensure: removed/,
-        /Registry_value\[32:hklm.Software.Vendor.PuppetLabsTest\w+.SubKeyToPurge.Value3\].ensure: removed/
+        /Registry_value\[Generated_32:hklm\\Software\\Vendor\\PuppetLabsTest\w+.SubKeyToPurge\\Value1_[\w-]+\].ensure: removed/,
+        /Registry_value\[Generated_32:hklm\\Software\\Vendor\\PuppetLabsTest\w+.SubKeyToPurge\\Value2_[\w-]+\].ensure: removed/,
+        /Registry_value\[Generated_32:hklm\\Software\\Vendor\\PuppetLabsTest\w+.SubKeyToPurge\\Value3_[\w-]+\].ensure: removed/,
     ]
 
     windows_agents.each do |agent|

--- a/spec/classes/mixed_default_settings_spec.rb
+++ b/spec/classes/mixed_default_settings_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-# The manifest used for testing, is located in spec/fixtures/mixed_default_settings/manifests/init.pp
+# The manifest used for testing, is located in spec/fixtures/test_registry/manifests/manifests/mixed_default_settings.pp
 
 # This test is to ensure that the way of setting default values (trailing slash) compiles correctly
 # when there is a similar looking path in the manifest. It mixes default and non-default value_names in the same manifest
@@ -17,7 +17,7 @@ require 'spec_helper'
 #                                    This is the 'hklm\Software\foo\\' resource
 #
 
-describe 'mixed_default_settings' do
+describe 'test_registry::mixed_default_settings' do
   it { is_expected.to compile }
 
   it { is_expected.to contain_registry_value('hklm\Software\foo\\') }

--- a/spec/classes/titles_and_aliases_spec.rb
+++ b/spec/classes/titles_and_aliases_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+# The manifest used for testing, is located in spec/fixtures/test_registry/manifests/titles_and_aliases.pp
+
+# This test is to ensure that the titles used in a manifest that appear to be unique are indeed unique and
+# compile to a manifest correctly.
+#
+# Typically the title_patterns for the type split the string into its components however there can be cases
+# where title_pattern values clash with explicitly set resource values which can then cause aliasing errors
+#
+# For example;
+#   Cannot alias Registry_value[HKLM\Software\foo2] to ["HKLM\\Software", "Value1"] at C:/Source/puppetlabs-registry/
+#   registry/spec/fixtures/modules/test_registry/manifests/titles_and_aliases.pp:7;
+#   resource ["Registry_value", "HKLM\\Software", "Value1"] already declared at .../spec/fixtures/modules/test_registry/manifests/titles_and_aliases.pp:2
+
+describe 'test_registry::titles_and_aliases' do
+  it { is_expected.to compile }
+
+  it { is_expected.to contain_registry_value('HKLM\Software\foo1') }
+  it { is_expected.to contain_registry_value('HKLM\Software\foo2') }
+  it { is_expected.to contain_registry_value('foo3') }
+end

--- a/spec/fixtures/test_registry/manifests/mixed_default_settings.pp
+++ b/spec/fixtures/test_registry/manifests/mixed_default_settings.pp
@@ -1,4 +1,4 @@
-class mixed_default_settings {
+class test_registry::mixed_default_settings {
   registry_value { 'hklm\Software\foo\\':
     ensure => present,
     type   => string,

--- a/spec/fixtures/test_registry/manifests/titles_and_aliases.pp
+++ b/spec/fixtures/test_registry/manifests/titles_and_aliases.pp
@@ -1,0 +1,17 @@
+class test_registry::titles_and_aliases {
+  registry_value { 'HKLM\Software\foo1':
+    value_name => 'Value1',
+    data       => "Should be HKLM\Software\foo1\Value1",
+  }
+
+  registry_value { 'HKLM\Software\foo2':
+    value_name => 'Value1',
+    data       => "Should be HKLM\Software\foo2\Value1",
+  }
+
+  registry_value { 'foo3':
+    path       =>'HKLM\Software\foo3':
+    value_name => 'Value1',
+    data       => "Should be HKLM\Software\foo3\Value1",
+  }
+}

--- a/spec/unit/puppet/provider/registry_value_spec.rb
+++ b/spec/unit/puppet/provider/registry_value_spec.rb
@@ -61,14 +61,14 @@ describe Puppet::Type.type(:registry_value).provider(:registry), :if => Puppet.f
     end
 
     it "should return false for a bogus hive/path" do
-      reg_value = type.new(:path => 'hklm\foobar5000', :catalog => catalog, :provider => described_class.name)
+      reg_value = type.new(:title => 'hklm\foobar5000', :catalog => catalog, :provider => described_class.name)
       reg_value.provider.exists?.should be false
     end
   end
 
   describe "#regvalue" do
     it "should return a valid string for a well known key" do
-      reg_value = type.new(:path => 'hklm\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SystemRoot', :provider => described_class.name)
+      reg_value = type.new(:title => 'hklm\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SystemRoot', :provider => described_class.name)
       reg_value.provider.data.should eq [ENV['SystemRoot']]
       reg_value.provider.type.should eq :string
     end
@@ -90,7 +90,7 @@ describe Puppet::Type.type(:registry_value).provider(:registry), :if => Puppet.f
     let (:default_path) { path = "hklm\\#{puppet_key}\\#{subkey_name}\\" }
     let (:path) { path = "hklm\\#{puppet_key}\\#{subkey_name}\\#{SecureRandom.uuid}" }
     def create_and_destroy(path, reg_type, data)
-      reg_value = type.new(:path => path,
+      reg_value = type.new(:title => path,
         :type => reg_type,
         :data => data,
         :provider => described_class.name)
@@ -141,14 +141,14 @@ describe Puppet::Type.type(:registry_value).provider(:registry), :if => Puppet.f
     let (:path) { path = "hklm\\#{puppet_key}\\#{subkey_name}\\#{SecureRandom.uuid}" }
 
     after(:each) do
-      reg_value = type.new(:path => path, :provider => described_class.name)
+      reg_value = type.new(:title => path, :provider => described_class.name)
 
       reg_value.provider.destroy
       expect(reg_value.provider).to_not be_exists
     end
 
     def write_and_read_value(path, reg_type, value)
-      reg_value = type.new(:path => path,
+      reg_value = type.new(:title => path,
         :type => reg_type,
         :data => value,
         :provider => described_class.name)
@@ -190,8 +190,7 @@ describe Puppet::Type.type(:registry_value).provider(:registry), :if => Puppet.f
       # character APIs, but passing wide strings to them (facepalm)
       # https://github.com/ruby/ruby/blob/v2_1_5/ext/win32/lib/win32/registry.rb#L323-L329
       # therefore, use our own code instead of hklm.delete_value
-
-      reg_value = type.new(:path => "hklm\\#{puppet_key}\\#{subkey_name}\\#{guid}",
+      reg_value = type.new(:title => "hklm\\#{puppet_key}\\#{subkey_name}\\#{guid}",
         :provider => described_class.name)
 
       reg_value.provider.destroy
@@ -210,7 +209,7 @@ describe Puppet::Type.type(:registry_value).provider(:registry), :if => Puppet.f
       utf_8_bytes = ENDASH_UTF_8 + TM_UTF_8
       utf_8_str = utf_8_bytes.pack('c*').force_encoding(Encoding::UTF_8)
 
-      reg_value = type.new(:path => "hklm\\#{puppet_key}\\#{subkey_name}\\#{guid}",
+      reg_value = type.new(:title => "hklm\\#{puppet_key}\\#{subkey_name}\\#{guid}",
         :type => :string,
         :data => utf_16_str,
         :provider => described_class.name)

--- a/spec/unit/puppet/type/registry_key_spec.rb
+++ b/spec/unit/puppet/type/registry_key_spec.rb
@@ -128,7 +128,6 @@ describe Puppet::Type.type(:registry_key) do
       end
 
       it "should purge existing values that are not being managed and case insensitive)" do
-        pending("eval_generate is currently not case insensitive, but should be")
         key.provider.expects(:values).returns(['VAL1', 'VaL\3', 'Val99'])
         resources = key.eval_generate
         resources.count.must == 1

--- a/spec/unit/puppet/type/registry_value_spec.rb
+++ b/spec/unit/puppet/type/registry_value_spec.rb
@@ -154,17 +154,17 @@ describe Puppet::Type.type(:registry_value) do
       # Explicit value names should overried title
       { :title => 'hklm\software\foo',
         :value_name          => 'value1',
-        :expected_path       => 'hklm\software',
+        :expected_path       => 'hklm\software\foo',
         :expected_value_name => 'value1',
       },
       { :title => 'hklm\software\foo',
         :value_name          => 'value\1',
-        :expected_path       => 'hklm\software',
+        :expected_path       => 'hklm\software\foo',
         :expected_value_name => 'value\1',
       },
       { :title => 'hklm\software\foo',
         :value_name          => 'value1\\',
-        :expected_path       => 'hklm\software',
+        :expected_path       => 'hklm\software\foo',
         :expected_value_name => 'value1\\',
       }].each do |testcase|
 

--- a/spec/unit/puppet/type/registry_value_spec.rb
+++ b/spec/unit/puppet/type/registry_value_spec.rb
@@ -2,7 +2,14 @@
 require 'spec_helper'
 require 'puppet/type/registry_value'
 
+# Helper method used when display describe text blocks to distinguish
+# between empty strings and nils
+def display_nil_string(value)
+  value.nil? ? '(nil)' : value
+end
+
 describe Puppet::Type.type(:registry_value) do
+  let (:title) { 'TestRegistryValue' }
   let (:catalog) do Puppet::Resource::Catalog.new end
 
   [:ensure, :type, :data].each do |property|
@@ -15,54 +22,50 @@ describe Puppet::Type.type(:registry_value) do
     end
   end
 
+  describe "value_name parameter" do
+    it "should have a value_name parameter" do
+      Puppet::Type.type(:registry_value).attrtype(:value_name).should == :param
+    end
+  end
+
   describe "path parameter" do
     it "should have a path parameter" do
       Puppet::Type.type(:registry_value).attrtype(:path).should == :param
     end
 
-    %w[hklm\propname hklm\software\propname].each do |path|
+    %w[hklm hklm\ hklm\propname hklm\software\propname].each do |path|
       it "should accept #{path}" do
-        described_class.new(:path => path, :catalog => catalog)
+        described_class.new(:title => title, :path => path, :catalog => catalog)
       end
     end
 
-    %w[hklm\\ hklm\software\\ hklm\software\vendor\\].each do |path|
-      it "should accept the unnamed (default) value: #{path}" do
-        described_class.new(:path => path, :catalog => catalog)
-      end
-    end
+    it "should strip trailling slashes from paths" do
+      value = described_class.new(:title => title, :path => 'hklm\\software\\\\', :catalog => catalog)
 
-    it "should strip trailling slashes from unnamed values" do
-      value = described_class.new(:path => 'hklm\\software\\\\', :catalog => catalog)
-
-      expect(value[:path]).to eq('hklm\\software\\')
+      expect(value[:path]).to eq('hklm\\software')
     end
 
     %w[HKEY_DYN_DATA\\ HKEY_PERFORMANCE_DATA\name].each do |path|
       it "should reject #{path} as unsupported" do
-        expect { described_class.new(:path => path, :catalog => catalog) }.to raise_error(Puppet::Error, /Unsupported/)
+        expect { described_class.new(:title => title, :path => path, :catalog => catalog) }.to raise_error(Puppet::Error, /Unsupported/)
       end
     end
 
-    %w[hklm hkcr unknown\\name unknown\\subkey\\name].each do |path|
+    %w[unknown\\name unknown\\subkey\\name].each do |path|
       it "should reject #{path} as invalid" do
-        expect { described_class.new(:path => path, :catalog => catalog) }.to raise_error(Puppet::Error, /Invalid registry key/)
+        expect { described_class.new(:title => title, :path => path, :catalog => catalog) }.to raise_error(Puppet::Error, /Invalid registry key/)
       end
     end
 
     %w[HKLM\\name HKEY_LOCAL_MACHINE\\name hklm\\name].each do |root|
       it "should canonicalize root key #{root}" do
-        value = described_class.new(:path => root, :catalog => catalog)
+        value = described_class.new(:title => title, :path => root, :catalog => catalog)
         value[:path].should == 'hklm\name'
       end
     end
 
-    it 'should validate the length of the value name'
-    it 'should validate the length of the value data'
-    it 'should be case-preserving'
-    it 'should be case-insensitive'
-    it 'should support 32-bit values' do
-      value = described_class.new(:path => '32:hklm\software\foo', :catalog => catalog)
+    it 'should accept 32-bit values' do
+      described_class.new(:title => title, :path => '32:hklm\software\foo', :catalog => catalog)
     end
   end
 
@@ -111,7 +114,7 @@ describe Puppet::Type.type(:registry_value) do
   end
 
   describe "type property" do
-    let (:value) { described_class.new(:path => 'hklm\software\foo', :catalog => catalog) }
+    let (:value) { described_class.new(:title => title, :path => 'hklm\software\foo', :catalog => catalog) }
 
     [:string, :array, :dword, :qword, :binary, :expand].each do |type|
       it "should support a #{type.to_s} type" do
@@ -125,8 +128,70 @@ describe Puppet::Type.type(:registry_value) do
     end
   end
 
+  describe "title property" do
+    [ { :title => 'hklm\software\foo',
+        :expected_path       => 'hklm\software',
+        :expected_value_name => 'foo',
+      },
+      # Default values are specified with a trailing slash
+      { :title => 'hklm\software\foo\\',
+        :expected_path       => 'hklm\software\foo',
+        :expected_value_name => '',
+      },
+      # Default values are specified with an empty value_name
+      { :title => 'hklm\software\foo',
+        :value_name          => '',
+        :expected_path       => 'hklm\software',
+        :expected_value_name => '',
+      },
+      # Explicit paths should overried title
+      { :title => 'hklm\software\foo',
+        :path                => 'hklm\different\path',
+        :value_name          => 'value1',
+        :expected_path       => 'hklm\different\path',
+        :expected_value_name => 'value1',
+      },
+      # Explicit value names should overried title
+      { :title => 'hklm\software\foo',
+        :value_name          => 'value1',
+        :expected_path       => 'hklm\software',
+        :expected_value_name => 'value1',
+      },
+      { :title => 'hklm\software\foo',
+        :value_name          => 'value\1',
+        :expected_path       => 'hklm\software',
+        :expected_value_name => 'value\1',
+      },
+      { :title => 'hklm\software\foo',
+        :value_name          => 'value1\\',
+        :expected_path       => 'hklm\software',
+        :expected_value_name => 'value1\\',
+      }].each do |testcase|
+
+      context "given a title of '#{testcase[:title]}', path of '#{display_nil_string(testcase[:path])}', and value_name of '#{display_nil_string(testcase[:value_name])}'" do
+        let (:value) {
+          params = {
+            :title => testcase[:title],
+            :catalog => catalog
+          }
+          params[:value_name] = testcase[:value_name] unless testcase[:value_name].nil?
+          params[:path] = testcase[:path] unless testcase[:path].nil?
+
+          described_class.new(params)
+        }
+
+        it "should use registry value name of '#{testcase[:expected_value_name]}'" do
+          expect(value[:value_name]).to eq(testcase[:expected_value_name])
+        end
+        it "should use registry path of '#{testcase[:expected_path]}'" do
+          expect(value[:path]).to eq(testcase[:expected_path])
+        end
+      end
+    end
+  end
+
   describe "data property" do
-    let (:value) { described_class.new(:path => 'hklm\software\foo', :catalog => catalog) }
+    let (:value) { described_class.new(:title => title, :path => 'hklm\software\foo', :catalog => catalog) }
 
     context "string data" do
       ['', 'foobar'].each do |data|
@@ -135,8 +200,6 @@ describe Puppet::Type.type(:registry_value) do
           value[:data] = data
         end
       end
-
-      pending "it should accept nil"
     end
 
     context "integer data" do


### PR DESCRIPTION
Note - Builds on PR #143

Previously the registry_value resource could not update values with a backslash
in their name.  This was due to using the path as a way of expressing a unique
registry value, however values can only be uniquely named using a path and name.

This means the registry_value type needed a new parameter called `value_name`
which is a namevar.  Fortunately registry keys can not have a backslash in their
name so title_patterns could be used to split a resource title into it's path
and value name components.  This meant the type could maintain a level of
backwards compatibility.

This meant however that many of the assumptions about the :path parameter were
no longer true;
* It no longer contained the registry value_name (that is now in a separate
  param) so canonicalization is now the same as a registry_key
* Trailing backslashes needed to be deleted instead of kept
* Almost all of the custom code for the RegistryValuePath type was now redundant
* In most of the test cases, :path was used but this is no longer enough to
  identify a unique reg key value (It needs a Path and Value), however this
  could simply be changed to :title and then the title_pattern matching would
  extract the path and value_name.  This could also verify the backwards
  compatibiltiy behaviour of using a title

This commit also updates the unit tests for the new value_name parameter.

Unfortunately this is a breaking change even with the title_patterns.  Consider
the following:
```puppet
  registry_value { 'atitle\value':
    path => 'HKLM\Software\foo',
  }
```
Previously this would manage the value called 'foo' in the key 'HKLM\Software'.
With this change it would manage the value called 'value' (extracted from the
title_pattern because value_name is not specified) in the key 'HKLM\Software\foo'

```puppet
  registry_value { 'atitle':
    path => 'HKLM\Software\foo',
  }
```
Previously this would manage the value called 'foo' in the key 'HKLM\Software'.
With this change it would manage the default value (extracted from the
title_pattern because value_name is not specified) in the key 'HKLM\Software\foo'

- [x] Get it to work
- [x] Add tests
- [x] Confirm munging is no longer required
- [x] Add acceptance tests
- [x] Update documentation
- [ ] Test puppet resource