### PR TITLE
(MODULES-2957) Fix registry_value tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,4 @@
 fixtures:
   symlinks:
     registry: "#{source_dir}"
+    mixed_default_settings: "#{source_dir}/spec/fixtures/mixed_default_settings"

--- a/lib/puppet_x/puppetlabs/registry.rb
+++ b/lib/puppet_x/puppetlabs/registry.rb
@@ -135,7 +135,7 @@ module Registry
       # preserve the trailing backslash for the provider, otherwise it won't
       # think this is a default value.
       if default?
-        filter_path[:canonical] << "\\"
+        filter_path[:canonical] + "\\"
       else
         filter_path[:canonical]
       end
@@ -155,6 +155,16 @@ module Registry
 
     def default?
       !!filter_path[:is_default]
+    end
+
+    def filter_path
+      result = super
+
+      # It's possible to pass in a path of 'hklm' which can still be parsed, but is not valid registry key.  Only the default value 'hklm\'
+      # and named values 'hklm\something' are allowed
+      raise ArgumentError, "Invalid registry key: #{path}" if result[:trailing_path].empty? && result[:valuename].empty? && !result[:is_default]
+
+      result
     end
   end
 end

--- a/spec/classes/mixed_default_settings_spec.rb
+++ b/spec/classes/mixed_default_settings_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+# The manifest used for testing, is located in spec/fixtures/mixed_default_settings/manifests/init.pp
+
+# This test is to ensure that the way of setting default values (trailing slash) compiles correctly
+# when there is a similar looking path in the manifest. It mixes default and non-default value_names in the same manifest
+#
+# This manifest attempts to manage two registry values
+#
+# + HKLM
+#     + Software
+#         - foo                  <-- This is a value called 'foo' in the 'HKLM\Sofware' key.
+#         |                          This is the 'hklm\Software\foo' resource
+#         |
+#         + foo
+#             + (default value)  <-- This is the default value for a key called 'HKLM\Software\foo'.
+#                                    This is the 'hklm\Software\foo\\' resource
+#
+
+describe 'mixed_default_settings' do
+  it { is_expected.to compile }
+
+  it { is_expected.to contain_registry_value('hklm\Software\foo\\') }
+  it { is_expected.to contain_registry_value('hklm\Software\foo') }
+end

--- a/spec/fixtures/mixed_default_settings/manifests/init.pp
+++ b/spec/fixtures/mixed_default_settings/manifests/init.pp
@@ -1,0 +1,13 @@
+class mixed_default_settings {
+  registry_value { 'hklm\Software\foo\\':
+    ensure => present,
+    type   => string,
+    data   => 'default',
+  }
+
+  registry_value { 'hklm\Software\foo':
+    ensure => present,
+    type   => string,
+    data   => 'nondefault',
+  }
+}

--- a/spec/unit/puppet/provider/registry_value_spec.rb
+++ b/spec/unit/puppet/provider/registry_value_spec.rb
@@ -51,7 +51,12 @@ describe Puppet::Type.type(:registry_value).provider(:registry), :if => Puppet.f
 
   describe "#exists?" do
     it "should return true for a well known hive" do
-      reg_value = type.new(:path => 'hklm\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SoftwareType', :provider => described_class.name)
+      reg_value = type.new(:title => 'hklm\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SoftwareType', :provider => described_class.name)
+      reg_value.provider.exists?.should be true
+    end
+
+    it "should return true for a well known hive with mixed case name" do
+      reg_value = type.new(:title => 'hklm\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SoftwareType'.upcase, :provider => described_class.name)
       reg_value.provider.exists?.should be true
     end
 
@@ -82,6 +87,7 @@ describe Puppet::Type.type(:registry_value).provider(:registry), :if => Puppet.f
   end
 
   describe "#destroy" do
+    let (:default_path) { path = "hklm\\#{puppet_key}\\#{subkey_name}\\" }
     let (:path) { path = "hklm\\#{puppet_key}\\#{subkey_name}\\#{SecureRandom.uuid}" }
     def create_and_destroy(path, reg_type, data)
       reg_value = type.new(:path => path,
@@ -100,6 +106,10 @@ describe Puppet::Type.type(:registry_value).provider(:registry), :if => Puppet.f
 
       reg_value.provider.destroy
       reg_value.provider.exists?.should be false
+    end
+
+    it "can destroy a randomly created default REG_SZ value" do
+      create_and_destroy(default_path, :string, SecureRandom.uuid)
     end
 
     it "can destroy a randomly created REG_SZ value" do

--- a/spec/unit/puppet/type/registry_key_spec.rb
+++ b/spec/unit/puppet/type/registry_key_spec.rb
@@ -39,7 +39,7 @@ describe Puppet::Type.type(:registry_key) do
         key[:path] = path
       end
     end
-    
+
     %w[hku hku\.DEFAULT hku\.DEFAULT\software hku\.DEFAULT\software\vendor].each do |path|
       it "should accept #{path}" do
         key[:path] = path
@@ -110,6 +110,18 @@ describe Puppet::Type.type(:registry_key) do
         res[:path].must == "#{key[:path]}\\val3"
       end
 
+      it "should purge existing values that are not being managed and case insensitive)" do
+        pending("eval_generate is currently not case insensitive, but should be")
+        key.provider.expects(:values).returns(['VAL1', 'VaL\3', 'Val99'])
+        resources = key.eval_generate
+        resources.count.must == 1
+        res = resources.first
+
+        res[:ensure].must == :absent
+        res[:path].must == key[:path]
+        res[:value_name].must == 'Val99'
+      end
+
       it "should return an empty array if all existing values are being managed" do
         key.provider.expects(:values).returns(['val1', 'val2'])
         key.eval_generate.must be_empty
@@ -117,7 +129,7 @@ describe Puppet::Type.type(:registry_key) do
     end
   end
 
-  describe "#autorequire" do
+  describe "resource aliases" do
     let :the_catalog do
       Puppet::Resource::Catalog.new
     end


### PR DESCRIPTION
Previously the tests for the registry_value type were incomplete or were not
testing what they said they were.  This commit;
* Adds a compile test for when one resource is setting a default value and
  another is not, but shares the same name.  A fix for this was implemented
  in 64bba67 however there were no tests for this behaviour
* Fixed a bug in the canonicalising of path names which would append a backslash
  every time the method was called
* Actually tested that multiple backslashes are removed on the path
* Raised errors when an non default, but root only path was passed into a
  registry value.  This is different to registry keys, where this is allowed.
* Added tests for autorequiring of registry_key from registry_value resources
* Added tests in the registry_value provider for creating and destroying default
  values
* Added registry_value provider tests for case-insensitive exists? method and
  added for creating and destroying default values
* Fixed typo in the registry_key type tests whereby it was actually testing the
  resource aliases, not the autorequire of the type