### PR TITLE
(MODULES-6528) Fix registry::value defined type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
+#### Fixed
+- Fix the restrictive typing introduced for the registry::value defined type to once again allow numeric values to be specified for DWORD, QWORD and arrays for REG_MULTI_SZ values ([MODULES-6528](https://tickets.puppetlabs.com/browse/MODULES-6528))
+
 ## [2.0.0] - 2018-01-26
 ### Added
 - Add support for Puppet 5 ([MODULES-5144](https://tickets.puppetlabs.com/browse/MODULES-5144))

--- a/manifests/value.pp
+++ b/manifests/value.pp
@@ -43,7 +43,11 @@ define registry::value (
   Pattern[/^\w+/]           $key,
   Optional[String]          $value = undef,
   Optional[Pattern[/^\w+/]] $type = 'string',
-  Optional[String]          $data  = undef,
+  Optional[Variant[
+    String,
+    Numeric,
+    Array[Variant[String]
+  ]]]                       $data  = undef,
 ) {
 
   # ensure windows os

--- a/spec/defines/value_spec.rb
+++ b/spec/defines/value_spec.rb
@@ -38,4 +38,57 @@ RSpec.describe 'registry::value', :type => :define do
 
     it { is_expected.to compile.and_raise_error(/parameter 'type'/) }
   end
+
+  context 'Given a resource with string data' do
+    let(:params) {{
+       :key  => 'HKLM\Software\Vendor',
+       :data => 'KingKongBundy'
+    }}
+
+    it { is_expected.to compile }
+  end
+
+  ['dword', 'qword'].each do |type|
+    context "Given a resource with #{type} numeric data" do
+      let(:params) {{
+         :key  => 'HKLM\Software\Vendor',
+         :type => type,
+         :data => 42,
+      }}
+
+      it { is_expected.to compile }
+    end
+  end
+
+  context 'Given a resource with binary data' do
+    let(:params) {{
+       :key  => 'HKLM\Software\Vendor',
+       :type => 'binary',
+       :data => '1'
+    }}
+
+    it { is_expected.to compile }
+  end
+
+  ['string', 'expand'].each do |type|
+    context "Given a resource with string data typed as '#{type}'" do
+      let(:params) {{
+        :key  => 'HKLM\Software\Vendor',
+        :data => 'RavishingRickRude',
+        :type => type,
+      }}
+
+      it { is_expected.to compile }
+    end
+  end
+
+  context 'Given a resource with array data' do
+    let(:params) {{
+       :key  => 'HKLM\Software\Vendor',
+       :data => ['JakeTheSnake', 'AndreTheGiant'],
+       :type => 'array',
+    }}
+
+    it { is_expected.to compile }
+  end
 end


### PR DESCRIPTION
- Demonstrate the bug introduced in the 2.0.0 release as part of
   48a0b07

 - Tests for dword, qword and array type values currently fail in the first 
   commit given the defined type doesn't properly type the $data value to
   allow numeric values or arrays.

 - Fix the bug introduced in 48a0b07
   that did not have lenient enough typing for the $data parameter to
   the registry::value defined type.

 - This commit adds support for numerics, which are necessary for
   dword and qword. It also adds support for arrays, which are always
   an array of strings (corresponding to REG_MULTI_SZ).