### PR TITLE
(maint) Simplify registry::value type definition

### DIFF
--- a/manifests/value.pp
+++ b/manifests/value.pp
@@ -46,8 +46,8 @@ define registry::value (
   Optional[Variant[
     String,
     Numeric,
-    Array[Variant[String]
-  ]]]                       $data  = undef,
+    Array[String]
+  ]]                       $data  = undef,
 ) {
 
   # ensure windows os


### PR DESCRIPTION
 - The Variant in Array[Variant[String]] is completely unnecessary
   and can be simplified to Array[String]