### PR TITLE
(MODULES-6818) Fix types to no longer use unsupported proc title patterns

### DIFF
--- a/lib/puppet/type/registry_key.rb
+++ b/lib/puppet/type/registry_key.rb
@@ -24,7 +24,7 @@ Puppet::Type.newtype(:registry_key) do
 EOT
 
   def self.title_patterns
-    [ [ /^(.*?)\Z/m, [ [ :path, lambda{|x| x} ] ] ] ]
+    [ [ /^(.*?)\Z/m, [ [ :path ] ] ] ]
   end
 
   ensurable

--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -19,7 +19,7 @@ Puppet::Type.newtype(:registry_value) do
   EOT
 
   def self.title_patterns
-    [[/^(.*?)\Z/m, [[:path, lambda { |x| x }]]]]
+    [[/^(.*?)\Z/m, [[:path]]]]
   end
 
   ensurable


### PR DESCRIPTION
This change will fix errors when running `puppet generate types`

Errors:
```
Error: /etc/puppetlabs/code/environments/production/modules/registry/lib/puppet/type/registry_key.rb: title patterns that use procs are not supported.
Error: /etc/puppetlabs/code/environments/production/modules/registry/lib/puppet/type/registry_value.rb: title patterns that use procs are not supported.
```

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-registry/blob/master/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=11482&summary=%5BREGISTRY%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MASTER branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
