### PR TITLE
(MODULES-7534) Use case insensitive search when purging

### DIFF
--- a/lib/puppet/type/registry_key.rb
+++ b/lib/puppet/type/registry_key.rb
@@ -103,7 +103,7 @@ EOT
 
     # get the "should" names of registry values associated with this key
     should_values = catalog.relationship_graph.direct_dependents_of(self).select {|dep| dep.type == :registry_value }.map do |reg|
-      PuppetX::Puppetlabs::Registry::RegistryValuePath.new(reg.parameter(:path).value).valuename
+      PuppetX::Puppetlabs::Registry::RegistryValuePath.new(reg.parameter(:path).value).valuename.downcase
     end
 
     # get the "is" names of registry values associated with this key

--- a/spec/unit/puppet/type/registry_key_spec.rb
+++ b/spec/unit/puppet/type/registry_key_spec.rb
@@ -94,7 +94,7 @@ describe Puppet::Type.type(:registry_key) do
         key[:purge_values] = true
         catalog.add_resource(key)
         catalog.add_resource(Puppet::Type.type(:registry_value).new(:path => "#{key[:path]}\\val1", :catalog => catalog))
-        catalog.add_resource(Puppet::Type.type(:registry_value).new(:path => "#{key[:path]}\\val2", :catalog => catalog))
+        catalog.add_resource(Puppet::Type.type(:registry_value).new(:path => "#{key[:path]}\\vAl2", :catalog => catalog))
         catalog.add_resource(Puppet::Type.type(:registry_value).new(:path => "#{key[:path]}\\\\val\\3", :catalog => catalog))
       end
 


### PR DESCRIPTION
Previously when the `purge_values` parameter was set to true, it would fail on
registry values which contained an uppercase name, and already exsts.  This was
due to the array comparison using `.downcase` for the is_value elements, but
not doing the same for the should_values elements.

This commit changes the should_values elements to always be downcased thereby
making the later comparison valid.  This commit also updates the tests, which
would now fail if the fix was not applied.
