### PR TITLE
(maint) Remove redundant comment in .sync.yml

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -54,8 +54,6 @@ appveyor.yml:
       RUBY_VERSION: 24-x64
       CHECK: spec
 
-# appveyor.yml:
-#   unmanaged: true
 .gitlab-ci.yml:
   delete: true
 


### PR DESCRIPTION
The .sync.yml file had an errant comment in the file.  This commit removes the text as it has no affect.
