### PR TITLE
(MODULES-5625) Fail on empty strings in REG_MULTI_SZ

### DIFF
--- a/lib/puppet/provider/registry_value/registry.rb
+++ b/lib/puppet/provider/registry_value/registry.rb
@@ -100,6 +100,7 @@ Puppet::Type.type(:registry_value).provide(:registry) do
           if Puppet::Util::Windows::Registry.RegQueryValueExW(reg.hkey, valuename_ptr,
             FFI::MemoryPointer::NULL, FFI::MemoryPointer::NULL,
             FFI::MemoryPointer::NULL, FFI::MemoryPointer::NULL) == 0
+            # Note - This actually calls read from Win32::Registry not Puppet::Util::Windows::Registry
             @regvalue[:type], @regvalue[:data] = from_native(reg.read(valuename))
           end
         end

--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -74,6 +74,15 @@ Puppet::Type.newtype(:registry_value) do
 
     defaultto ''
 
+    validate do |value|
+      case resource[:type]
+      when :array
+        fail("An array registry value can not contain empty values") if value.empty?
+      else
+        true
+      end
+    end
+
     munge do |value|
       case resource[:type]
       when :dword

--- a/spec/unit/puppet/type/registry_value_spec.rb
+++ b/spec/unit/puppet/type/registry_value_spec.rb
@@ -219,6 +219,18 @@ describe Puppet::Type.type(:registry_value) do
         value[:type] = :array
         value[:data] = ['foo', 'bar', 'baz']
       end
+
+      it "should support an empty array" do
+        value[:type] = :array
+        value[:data] = []
+      end
+
+      [ [''], nil, ['', 'foo', 'bar'], ['foo', '', 'bar'], ['foo', 'bar', ''] ].each do |data|
+        it "should reject '#{data}'" do
+          value[:type] = :array
+          expect { value[:data] = data }.to raise_error(Puppet::Error)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Previously it possible to pass in empty strings into REG_MULTI_SZ
registry types, however according to the Microsoft documentation [1]
this is not allowed.

This commit modifies the registry_value type to validate incoming
array infomration and to fail if this data is passed through.

This commit also adds tests for these scenarios.

[1] https://docs.microsoft.com/en-us/windows/desktop/sysinfo/registry-value-types