### PR TITLE
MODULES-9195 - Handle corrupt registry_values in a graceful way

### DIFF
--- a/lib/puppet/provider/registry_value/registry.rb
+++ b/lib/puppet/provider/registry_value/registry.rb
@@ -100,8 +100,14 @@ Puppet::Type.type(:registry_value).provide(:registry) do
           if Puppet::Util::Windows::Registry.RegQueryValueExW(reg.hkey, valuename_ptr,
             FFI::MemoryPointer::NULL, FFI::MemoryPointer::NULL,
             FFI::MemoryPointer::NULL, FFI::MemoryPointer::NULL) == 0
-            # Note - This actually calls read from Win32::Registry not Puppet::Util::Windows::Registry
-            @regvalue[:type], @regvalue[:data] = from_native(reg.read(valuename))
+            contents = ''
+            begin
+              # Note - This actually calls read from Win32::Registry not Puppet::Util::Windows::Registry
+              contents = reg.read(valuename)
+            rescue Encoding::InvalidByteSequenceError => e
+              Puppet.log_exception(e, "#{e} when reading registry value for '#{valuename}'")
+            end
+            @regvalue[:type], @regvalue[:data] = from_native(contents)
           end
         end
       end

--- a/spec/unit/puppet/provider/registry_value_spec.rb
+++ b/spec/unit/puppet/provider/registry_value_spec.rb
@@ -99,6 +99,15 @@ describe Puppet::Type.type(:registry_value).provider(:registry) do
       type, data = reg.from_native([3, "\x1"])
       data.should eq ['01']
     end
+
+    xit "should gracefully handle corrupt registry values" do
+      reg = described_class.new 
+      broken_encoding = [0xd800].pack('U')
+      type, data = reg.from_native([3, broken_encoding])  
+      data.should eql ['']
+    end
+
+
   end
 
   describe "#destroy" do


### PR DESCRIPTION
Corrupt registry entries raise an exception when read this prevents which prevents the desired state being enforced.

Ideally there should be some kind of mechanism for these errors should be handled gracefully. 

If gracefully handling is not the default case then a new parameter could be added to allow the user to choose the desired behaviour when read errors are encountered.

The spec test is a WIP as rspec itself will raise an exception when values have invalid encoding. I will continue to work on this but comments, guidance and suggestions very welcome on how to do this.
