### PR TITLE
MODULES-9802 Repair broken project url to point at repo

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "summary": "This module provides a native type and provider to manage keys and values in the Windows Registry",
   "license": "Apache-2.0",
   "source": "git://github.com/puppetlabs/puppetlabs-registry.git",
-  "project_page": "http://links.puppet.com/registry-module",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-registry",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
 


### PR DESCRIPTION
This commit updates the metadata so that rather than pointing at
a non-existent URL -- which was redirecting folks to the main
puppet.com page -- it now points at the github repository for the
project, just like virtually all of our other modules.