### PR TITLE
(maint) - Add support for Changelog Generator

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,6 @@ AllCops:
   - "**/Rakefile"
   - pkg/**/*
   - spec/fixtures/**/*
-  - spec/**/*
   - vendor/**/*
   - "**/Puppetfile"
   - "**/Vagrantfile"
@@ -28,7 +27,6 @@ GetText/DecorateString:
   Description: We don't want to decorate test output.
   Exclude:
   - spec/**/*
-Lint/AssignmentInCondition:
   Enabled: false
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
@@ -43,9 +41,8 @@ Style/BlockDelimiters:
     be consistent then.
   EnforcedStyle: braces_for_chaining
 Style/ClassAndModuleChildren:
-  Enabled: false
-Style/DoubleNegation:
-  Enabled: false
+  Description: Compact style reduces the required amount of indentation.
+  EnforcedStyle: compact
 Style/EmptyElse:
   Description: Enforce against empty else clauses, but allow `nil` for clarity.
   EnforcedStyle: empty
@@ -92,6 +89,12 @@ Style/MethodCalledOnDoEndBlock:
   Enabled: true
 Style/StringMethods:
   Enabled: true
+GetText/DecorateFunctionMessage:
+  Enabled: false
+GetText/DecorateStringFormattingUsingInterpolation:
+  Enabled: false
+GetText/DecorateStringFormattingUsingPercent:
+  Enabled: false
 Layout/EndOfLine:
   Enabled: false
 Layout/IndentHeredoc:

--- a/.sync.yml
+++ b/.sync.yml
@@ -14,6 +14,13 @@ Gemfile:
       - gem: master_manipulator
       - gem: puppet-blacksmith
         version: '~> 3.4'
+  optional:
+    ':development':
+      - gem: 'github_changelog_generator'
+        git: 'https://github.com/skywinder/github-changelog-generator'
+        ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')"
+
 
 .gitignore:
   required:

--- a/Gemfile
+++ b/Gemfile
@@ -23,10 +23,12 @@ group :development do
   gem "json", '= 1.8.1',                                         require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
   gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-posix-default-r#{minor_version}", '~> 0.3', require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.3',     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.3',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 0.3',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "github_changelog_generator",                              require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
 end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", require: false, platforms: [:ruby]

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,129 @@
+## 2.1.0
+### Added
+- Updated module for Puppet 6 ([MODULES-7832](https://tickets.puppetlabs.com/browse/MODULES-7832))
+
+### Changed
+- Update module for PDK ([MODULES-7404](https://tickets.puppetlabs.com/browse/MODULES-7404))
+
+## [2.0.2] - 2018-08-08
+### Added
+- Add Windows Server 2016 and Windows 10 as supported Operating Systems ([MODULES-4271](https://tickets.puppetlabs.com/browse/MODULES-4271))
+
+### Changed
+- Convert tests to use testmode switcher ([MODULES-6744](https://tickets.puppetlabs.com/browse/MODULES-6744))
+
+### Fixed
+- Fix types to no longer use unsupported proc title patterns ([MODULES-6818](https://tickets.puppetlabs.com/browse/MODULES-6818))
+- Fix acceptance tests in master-agent scenarios ([FM-6934](https://tickets.puppetlabs.com/browse/FM-6934))
+- Use case insensitive search when purging ([MODULES-7534](https://tickets.puppetlabs.com/browse/MODULES-7534))
+
+### Removed
+
+## [2.0.1] - 2018-01-25
+### Fixed
+- Fix the restrictive typing introduced for the registry::value defined type to once again allow numeric values to be specified for DWORD, QWORD and arrays for REG_MULTI_SZ values ([MODULES-6528](https://tickets.puppetlabs.com/browse/MODULES-6528))
+
+## [2.0.0] - 2018-01-24
+### Added
+- Add support for Puppet 5 ([MODULES-5144](https://tickets.puppetlabs.com/browse/MODULES-5144))
+
+### Changed
+- Convert beaker tests to beaker rspec tests ([MODULES-5976](https://tickets.puppetlabs.com/browse/MODULES-5976))
+
+#### Fixed
+- Ensure registry values that include a `\` as part of the name are valid and usable ([MODULES-2957](https://tickets.puppetlabs.com/browse/MODULES-2957))
+
+### Removed
+- **BREAKING:** Dropped support for Puppet 3
+
+## [1.1.4] - 2017-03-06
+### Added
+- Ability to manage keys and values in `HKEY_USERS` (`hku`) ([MODULES-3865](https://tickets.puppetlabs.com/browse/MODULES-3865))
+
+### Removed
+- Remove Windows Server 2003 from supported Operating System list
+
+#### Fixed
+- Use double quotes so $key is interpolated ([FM-5236](https://tickets.puppetlabs.com/browse/FM-5236))
+- Fix WOW64 Constant Definition ([MODULES-3195](https://tickets.puppetlabs.com/browse/MODULES-3195))
+- Fix UNSET no longer available as a bareword ([MODULES-4331](https://tickets.puppetlabs.com/browse/MODULES-4331))
+
+## [1.1.3] - 2015-12-08
+### Added
+- Support of newer PE versions.
+
+## [1.1.2] - 2015-08-13
+### Added
+- Added tests to catch scenario
+
+### Changed
+- Changed byte conversion to use pack instead
+
+### Fixed
+- Fix critical bug when writing dword and qword values.
+- Fix the way we write dword and qword values [MODULES-2409](https://tickets.puppet.com/browse/MODULES-2409)
+
+## [1.1.1] - 2015-08-12 [YANKED]
+### Added
+- Puppet Enterprise 2015.2.0 to metadata
+
+### Changed
+- Gemfile updates
+- Updated the logic used to convert to byte arrays
+
+### Fixed
+- Fixed Ruby registry writes corrupt string ([MODULES-1921](https://tickets.puppet.com/browse/MODULES-1921))
+- Fixed testcases
+
+## [1.1.0] - 2015-03-24
+### Fixes
+- Additional tests for purge_values
+- Use wide character registry APIs
+- Test Ruby Registry methods uncalled
+- Introduce Ruby 2.1.5 failing tests
+
+
+## [1.0.3] - 2014-08-25
+### Added
+- Added support for native x64 ruby and puppet 3.7
+
+### Fixed
+- Fixed issues with non-leading-zero binary values in registry keys.
+
+## [1.0.2] - 2014-07-15
+### Added
+- Added the ability to uninstall and upgrade the module via the `puppet module` command
+
+## [1.0.1] - 2014-05-20
+### Fixed
+- Add zero padding to binary single character inputs
+
+## [1.0.0] - 2014-03-04
+### Added
+- Add license file
+
+### Changed
+- Documentation updates
+
+## [0.1.2] - 2013-08-01
+### Added
+- Add geppetto project file
+
+### Changed
+- Updated README and manifest documentation
+- Refactored code into PuppetX namespace
+- Only manage redirected keys on 64 bit systems
+- Only use /sysnative filesystem when available
+- Use class accessor method instead of class instance variable
+
+### Fixed
+- Fixed unhandled exception when loading windows code on *nix
+
+## [0.1.1] - 2012-05-21
+### Fixed
+- Improve error handling when writing values
+- Fix management of the default value
+
+## [0.1.0] - 2012-05-16
+### Added
+- Initial release

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
  require 'puppetlabs_spec_helper/rake_tasks'
  require 'puppet-lint/tasks/puppet-lint'
  require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
+ require 'github_changelog_generator/task' if Bundler.rubygems.find_name('github_changelog_generator').any?
 begin
   require 'beaker/tasks/test'
 rescue LoadError
@@ -33,4 +34,83 @@ desc 'Generate code coverage'
 RSpec::Core::RakeTask.new(:coverage) do |t|
   t.rcov = true
   t.rcov_opts = ['--exclude', 'spec']
+end
+
+def changelog_user
+  return unless Rake.application.top_level_tasks.include? "changelog"
+  returnVal = nil || JSON.load(File.read('metadata.json'))['author']
+  raise "unable to find the changelog_user in .sync.yml, or the author in metadata.json" if returnVal.nil?
+  puts "GitHubChangelogGenerator user:#{returnVal}"
+  returnVal
+end
+
+def changelog_project
+  return unless Rake.application.top_level_tasks.include? "changelog"
+
+  returnVal = nil
+  returnVal ||= begin
+    metadata_source = JSON.load(File.read('metadata.json'))['source']
+    metadata_source_match = metadata_source && metadata_source.match(%r{.*\/([^\/]*?)(?:\.git)?\Z})
+
+    metadata_source_match && metadata_source_match[1]
+  end
+
+  raise "unable to find the changelog_project in .sync.yml or calculate it from the source in metadata.json" if returnVal.nil?
+
+  puts "GitHubChangelogGenerator project:#{returnVal}"
+  returnVal
+end
+
+def changelog_future_release
+  return unless Rake.application.top_level_tasks.include? "changelog"
+  returnVal = "v%s" % JSON.load(File.read('metadata.json'))['version']
+  raise "unable to find the future_release (version) in metadata.json" if returnVal.nil?
+  puts "GitHubChangelogGenerator future_release:#{returnVal}"
+  returnVal
+end
+
+PuppetLint.configuration.send('disable_relative')
+
+if Bundler.rubygems.find_name('github_changelog_generator').any?
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?
+    config.user = "#{changelog_user}"
+    config.project = "#{changelog_project}"
+    config.future_release = "#{changelog_future_release}"
+    config.exclude_labels = ['maintenance']
+    config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
+    config.add_pr_wo_labels = true
+    config.issues = false
+    config.merge_prefix = "### UNCATEGORIZED PRS; GO LABEL THEM"
+    config.configure_sections = {
+      "Changed" => {
+        "prefix" => "### Changed",
+        "labels" => ["backwards-incompatible"],
+      },
+      "Added" => {
+        "prefix" => "### Added",
+        "labels" => ["feature", "enhancement"],
+      },
+      "Fixed" => {
+        "prefix" => "### Fixed",
+        "labels" => ["bugfix"],
+      },
+    }
+  end
+else
+  desc 'Generate a Changelog from GitHub'
+  task :changelog do
+    raise <<EOM
+The changelog tasks depends on unreleased features of the github_changelog_generator gem.
+Please manually add it to your .sync.yml for now, and run `pdk update`:
+---
+Gemfile:
+  optional:
+    ':development':
+      - gem: 'github_changelog_generator'
+        git: 'https://github.com/skywinder/github-changelog-generator'
+        ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')"
+EOM
+  end
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,14 @@ environment:
       RUBY_VERSION: 25-x64
       CHECK: parallel_spec
     -
+      PUPPET_GEM_VERSION: ~> 4.0
+      RUBY_VERSION: 21
+      CHECK: spec
+    -
+      PUPPET_GEM_VERSION: ~> 4.0
+      RUBY_VERSION: 21-x64
+      CHECK: spec
+    -
       PUPPET_GEM_VERSION: ~> 5.0
       RUBY_VERSION: 24
       CHECK: spec

--- a/lib/puppet/provider/registry_key/registry.rb
+++ b/lib/puppet/provider/registry_key/registry.rb
@@ -44,7 +44,7 @@ Puppet::Type.type(:registry_key).provide(:registry) do
   def exists?
     Puppet.debug("Checking existence of registry key #{self}")
     begin
-      !!hive.open(subkey, Win32::Registry::KEY_READ | access) { |_reg| true }
+      !!hive.open(subkey, Win32::Registry::KEY_READ | access) { |_reg| true } # rubocop:disable Style/DoubleNegation
     rescue
       false
     end

--- a/lib/puppet_x/puppetlabs/registry.rb
+++ b/lib/puppet_x/puppetlabs/registry.rb
@@ -1,9 +1,11 @@
 # @api private
+# rubocop:disable Style/ClassAndModuleChildren
 module PuppetX
   # @api private
   module Puppetlabs
     # @api private
     module Registry
+      # rubocop:enable Style/ClassAndModuleChildren
       # For 64-bit OS, use 64-bit view. Ignored on 32-bit OS
       KEY_WOW64_64KEY = 0x100
       # For 64-bit OS, use 32-bit view. Ignored on 32-bit OS
@@ -86,7 +88,7 @@ module PuppetX
 
         def ascend
           p = canonical
-          while idx = p.rindex('\\')
+          while idx = p.rindex('\\') # rubocop:disable Lint/AssignmentInCondition
             p = p[0, idx]
             yield p
           end

--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
     }
   ],
   "description": "This module provides a native type and provider to manage keys and values in the Windows Registry",
-  "pdk-version": "1.11.1",
+  "pdk-version": "1.13.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates#master",
-  "template-ref": "heads/master-0-g7cf0403"
+  "template-ref": "1.14.0-0-g1bf3a4e"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "puppetlabs-registry",
   "version": "2.1.0",
-  "author": "Puppet Inc",
+  "author": "puppetlabs",
   "summary": "This module provides a native type and provider to manage keys and values in the Windows Registry",
   "license": "Apache-2.0",
   "source": "git://github.com/puppetlabs/puppetlabs-registry.git",

--- a/spec/acceptance/should_create_key_spec.rb
+++ b/spec/acceptance/should_create_key_spec.rb
@@ -100,6 +100,7 @@ PHASE3
     ]
 
     windows_agents.each do |agent|
+      # rubocop:disable RSpec/InstanceVariable
       agent_is_x64 = is_x64(agent)
       keys_created = keys_created_native + (agent_is_x64 ? keys_created_wow : [])
       values_purged = values_purged_native + (agent_is_x64 ? values_purged_wow : [])
@@ -138,6 +139,7 @@ PHASE3
           assert_no_match(%r{err:}, @result.stdout, 'Expected no error messages.')
         end
       end
+      # rubocop:enable RSpec/InstanceVariable
     end
   end
 end

--- a/spec/acceptance/should_have_defined_type_spec.rb
+++ b/spec/acceptance/should_have_defined_type_spec.rb
@@ -49,6 +49,7 @@ HERE
       %r{Registry_value\[HKLM\\Software\\Vendor\\PuppetLabsTest\w+\\\\Setting3\].data: data changed 'fact_phase=1' to 'fact_phase=2'},
     ]
     windows_agents.each do |agent|
+      # rubocop:disable RSpec/InstanceVariable
       it 'Phase 1.a - Create some values' do
         execute_manifest_on agent, manifest, get_apply_opts('FACTER_FACT_PHASE' => '1') do
           phase1_resources_created.each do |val_re|
@@ -84,6 +85,7 @@ HERE
           assert_no_match(%r{err:}, @result.stdout, 'Expected no error messages.')
         end
       end
+      # rubocop:enable RSpec/InstanceVariable
     end
   end
 end

--- a/spec/acceptance/should_manage_values_spec.rb
+++ b/spec/acceptance/should_manage_values_spec.rb
@@ -8,7 +8,7 @@ describe 'Registry Value Management' do
   vendor_path = 'HKLM\\Software\\Vendor'
   keypath = "#{vendor_path}\\#{keyname}"
 
-  def getManifest(keypath, vendor_path, phase)
+  def get_manifest(keypath, vendor_path, phase)
     <<P1
       notify { fact_phase: message => "fact_phase: #{phase}" }
       registry_key { '#{vendor_path}': ensure => present }
@@ -221,6 +221,8 @@ P1
 
       # This is just to save a whole bunch of copy / paste
       prefixes.each do |prefix|
+        # rubocop:disable Metrics/LineLength
+
         # We should have created 4 REG_SZ values
         1.upto(4).each do |idx|
           phase1_resources_created << %r{Registry_value\[#{prefix}HKLM.Software.Vendor.PuppetLabsTest\w+\\SubKey1\\ValueString#{idx}\].ensure: created}
@@ -263,10 +265,12 @@ P1
         # We have different data for the binary values
         phase2_resources_changed << %r{Registry_value\[#{prefix}HKLM.Software.Vendor.PuppetLabsTest\w+\\SubKey1\\ValueBinary1\].data: data changed '01' to '02'}
         phase2_resources_changed << %r{Registry_value\[#{prefix}HKLM.Software.Vendor.PuppetLabsTest\w+\\SubKey1\\ValueBinary2\].data: data changed 'de ad be ef ca f1' to 'de ad be ef ca f2'}
+        # rubocop:enable Metrics/LineLength
       end
 
+      # rubocop:disable RSpec/InstanceVariable
       it 'Registry Values - Phase 1.a - Create some values' do
-        execute_manifest_on agent, getManifest(keypath, vendor_path, '1'), get_apply_opts do
+        execute_manifest_on agent, get_manifest(keypath, vendor_path, '1'), get_apply_opts do
           assert_no_match(%r{err:}, @result.stdout, 'Expected no error messages.')
           phase1_resources_created.each do |val_re|
             assert_match(val_re, @result.stdout, "Expected output to contain #{val_re.inspect}.")
@@ -275,7 +279,7 @@ P1
       end
 
       it 'Registry Values - Phase 1.b - Make sure Puppet is idempotent' do
-        execute_manifest_on agent, getManifest(keypath, vendor_path, '1'), get_apply_opts do
+        execute_manifest_on agent, get_manifest(keypath, vendor_path, '1'), get_apply_opts do
           phase1_resources_created.each do |val_re|
             assert_no_match(val_re, @result.stdout, "Expected output to contain #{val_re.inspect}.")
           end
@@ -284,7 +288,7 @@ P1
       end
 
       it 'Registry Values - Phase 2.a - Change some values' do
-        execute_manifest_on agent, getManifest(keypath, vendor_path, '2'), get_apply_opts do
+        execute_manifest_on agent, get_manifest(keypath, vendor_path, '2'), get_apply_opts do
           assert_no_match(%r{err:}, @result.stdout, 'Expected no error messages.')
           phase2_resources_changed.each do |val_re|
             assert_match(val_re, @result.stdout, "Expected output to contain #{val_re.inspect}.")
@@ -293,7 +297,7 @@ P1
       end
 
       it 'Registry Values - Phase 2.b - Make sure Puppet is idempotent' do
-        execute_manifest_on agent, getManifest(keypath, vendor_path, '2'), get_apply_opts do
+        execute_manifest_on agent, get_manifest(keypath, vendor_path, '2'), get_apply_opts do
           phase2_resources_changed.each do |val_re|
             assert_no_match(val_re, @result.stdout, "Expected output to contain #{val_re.inspect}.")
           end
@@ -315,6 +319,7 @@ P1
           end
         end
       end
+      # rubocop:enable RSpec/InstanceVariable
     end
   end
 end

--- a/spec/unit/puppet/provider/registry_key_spec.rb
+++ b/spec/unit/puppet/provider/registry_key_spec.rb
@@ -1,11 +1,10 @@
-#! /usr/bin/env ruby
-
 require 'spec_helper'
 require 'puppet/type/registry_key'
 
 describe Puppet::Type.type(:registry_key).provider(:registry) do
-  let (:catalog) do Puppet::Resource::Catalog.new end
-  let (:type) { Puppet::Type.type(:registry_key) }
+  let(:catalog) { Puppet::Resource::Catalog.new }
+  let(:type) { Puppet::Type.type(:registry_key) }
+  let(:instance) { instance_double(Win32::Registry) }
 
   puppet_key = 'SOFTWARE\\Puppet Labs'
   subkey_name = 'PuppetRegProviderTest'
@@ -16,10 +15,13 @@ describe Puppet::Type.type(:registry_key).provider(:registry) do
     # a local codepage which can totally break when that codepage has no
     # conversion from the given UTF-16LE characters to local codepage
     # a prime example is that IBM437 has no conversion from a Unicode en-dash
-    expect_any_instance_of(Win32::Registry).to receive(:export_string).never
 
-    expect_any_instance_of(Win32::Registry).to receive(:delete_value).never
-    expect_any_instance_of(Win32::Registry).to receive(:delete_key).never
+    # rubocop:disable RSpec/ExpectInHook
+    expect(instance).to receive(:export_string).never
+
+    expect(instance).to receive(:delete_value).never
+    expect(instance).to receive(:delete_key).never
+    # rubocop:enable RSpec/ExpectInHook
   end
 
   describe '#destroy' do
@@ -42,8 +44,8 @@ describe Puppet::Type.type(:registry_key).provider(:registry) do
   end
 
   describe '#purge_values' do
-    let (:guid) { SecureRandom.uuid }
-    let (:reg_path) { "#{puppet_key}\\#{subkey_name}\\Unicode-#{guid}" }
+    let(:guid) { SecureRandom.uuid }
+    let(:reg_path) { "#{puppet_key}\\#{subkey_name}\\Unicode-#{guid}" }
 
     def bytes_to_utf8(bytes)
       bytes.pack('c*').force_encoding(Encoding::UTF_8)

--- a/spec/unit/puppet/type/registry_key_spec.rb
+++ b/spec/unit/puppet/type/registry_key_spec.rb
@@ -1,20 +1,17 @@
-#!/usr/bin/env ruby -S rspec
 require 'spec_helper'
 require 'puppet/resource'
 require 'puppet/resource/catalog'
 require 'puppet/type/registry_key'
 
 describe Puppet::Type.type(:registry_key) do
-  let (:catalog) do Puppet::Resource::Catalog.new end
+  let(:catalog) { Puppet::Resource::Catalog.new }
 
   # This is overridden here so we get a consistent association with the key
   # and a catalog using memoized let methods.
-  let (:key) do
-    Puppet::Type.type(:registry_key).new(name: 'HKLM\Software', catalog: catalog)
-  end
+  let(:key) { Puppet::Type.type(:registry_key).new(name: 'HKLM\Software', catalog: catalog) }
   let(:provider) { Puppet::Provider.new(key) }
 
-  before :each do
+  before(:each) do
     key.provider = provider
   end
 
@@ -33,6 +30,7 @@ describe Puppet::Type.type(:registry_key) do
       Puppet::Type.type(:registry_key).attrtype(:path).must == :param
     end
 
+    # rubocop:disable RSpec/RepeatedExample
     ['hklm', 'hklm\\software', 'hklm\\software\\vendor'].each do |path|
       it "should accept #{path}" do
         key[:path] = path
@@ -44,6 +42,7 @@ describe Puppet::Type.type(:registry_key) do
         key[:path] = path
       end
     end
+    # rubocop:enable RSpec/RepeatedExample
 
     ['HKEY_DYN_DATA', 'HKEY_PERFORMANCE_DATA'].each do |path|
       it "should reject #{path} as unsupported case insensitively" do
@@ -81,13 +80,11 @@ describe Puppet::Type.type(:registry_key) do
     end
 
     context 'purging' do
-      let (:catalog) do Puppet::Resource::Catalog.new end
+      let(:catalog) { Puppet::Resource::Catalog.new }
 
       # This is overridden here so we get a consistent association with the key
       # and a catalog using memoized let methods.
-      let (:key) do
-        Puppet::Type.type(:registry_key).new(name: 'HKLM\Software', catalog: catalog)
-      end
+      let(:key) { Puppet::Type.type(:registry_key).new(name: 'HKLM\Software', catalog: catalog) }
 
       before :each do
         key[:purge_values] = true
@@ -102,6 +99,7 @@ describe Puppet::Type.type(:registry_key) do
         key.eval_generate.must be_empty
       end
 
+      # rubocop:disable Lint/Void
       it 'purges existing values that are not being managed (without backslash)' do
         expect(key.provider).to receive(:values).and_return(['val1', 'val\3', 'val99'])
         resources = key.eval_generate
@@ -132,6 +130,7 @@ describe Puppet::Type.type(:registry_key) do
         res[:ensure].must == :absent
         res[:path].must == "#{key[:path]}\\Val99"
       end
+      # rubocop:enable Lint/Void
 
       it 'returns an empty array if all existing values are being managed' do
         expect(key.provider).to receive(:values).and_return(['val1', 'val2', 'val\3'])

--- a/spec/unit/puppet/type/registry_value_spec.rb
+++ b/spec/unit/puppet/type/registry_value_spec.rb
@@ -1,9 +1,8 @@
-#!/usr/bin/env ruby -S rspec
 require 'spec_helper'
 require 'puppet/type/registry_value'
 
 describe Puppet::Type.type(:registry_value) do
-  let (:catalog) do Puppet::Resource::Catalog.new end
+  let(:catalog) { Puppet::Resource::Catalog.new }
 
   [:ensure, :type, :data].each do |property|
     it "should have a #{property} property" do
@@ -19,7 +18,7 @@ describe Puppet::Type.type(:registry_value) do
     it 'has a path parameter' do
       Puppet::Type.type(:registry_value).attrtype(:path).should == :param
     end
-
+    # rubocop:disable RSpec/RepeatedExample
     ['hklm\\propname', 'hklm\\software\\propname'].each do |path|
       it "should accept #{path}" do
         described_class.new(path: path, catalog: catalog)
@@ -31,6 +30,7 @@ describe Puppet::Type.type(:registry_value) do
         described_class.new(path: path, catalog: catalog)
       end
     end
+    # rubocop:enable RSpec/RepeatedExample
 
     it 'strips trailling slashes from unnamed values' do
       value = described_class.new(path: 'hklm\\software\\\\', catalog: catalog)
@@ -81,12 +81,12 @@ describe Puppet::Type.type(:registry_value) do
     it 'should be case-preserving'
     it 'should be case-insensitive'
     it 'supports 32-bit values' do
-      value = described_class.new(path: '32:hklm\software\foo', catalog: catalog)
+      _value = described_class.new(path: '32:hklm\software\foo', catalog: catalog)
     end
   end
 
   describe '#autorequire' do
-    let(:subject) { described_class.new(title: subject_title, catalog: catalog) }
+    let(:instance) { described_class.new(title: subject_title, catalog: catalog) }
 
     [
       {
@@ -111,10 +111,10 @@ describe Puppet::Type.type(:registry_value) do
       },
     ].each do |testcase|
       context testcase[:context] do
-        let(:subject) { described_class.new(title: testcase[:reg_value_title], catalog: catalog) }
+        let(:instance) { described_class.new(title: testcase[:reg_value_title], catalog: catalog) }
 
         it 'does not autorequire ancestor keys if none exist' do
-          expect(subject.autorequire).to eq([])
+          expect(instance.autorequire).to eq([])
         end
 
         it 'onlies autorequire the nearest ancestor registry_key resource' do
@@ -122,7 +122,7 @@ describe Puppet::Type.type(:registry_value) do
           catalog.add_resource(Puppet::Type.type(:registry_key).new(path: 'hklm\Software\foo', catalog: catalog))
           catalog.add_resource(Puppet::Type.type(:registry_key).new(path: 'hklm\Software\foo\bar', catalog: catalog))
 
-          autorequire_array = subject.autorequire
+          autorequire_array = instance.autorequire
           expect(autorequire_array.count).to eq(1)
           expect(autorequire_array[0].to_s).to eq("Registry_key[#{testcase[:expected_reg_key_title]}] => Registry_value[#{testcase[:reg_value_title]}]")
         end
@@ -131,7 +131,7 @@ describe Puppet::Type.type(:registry_value) do
   end
 
   describe 'type property' do
-    let (:value) { described_class.new(path: 'hklm\software\foo', catalog: catalog) }
+    let(:value) { described_class.new(path: 'hklm\software\foo', catalog: catalog) }
 
     [:string, :array, :dword, :qword, :binary, :expand].each do |type|
       it "should support a #{type} type" do
@@ -146,7 +146,7 @@ describe Puppet::Type.type(:registry_value) do
   end
 
   describe 'data property' do
-    let (:value) { described_class.new(path: 'hklm\software\foo', catalog: catalog) }
+    let(:value) { described_class.new(path: 'hklm\software\foo', catalog: catalog) }
 
     context 'string data' do
       ['', 'foobar'].each do |data|
@@ -179,7 +179,7 @@ describe Puppet::Type.type(:registry_value) do
       end
 
       context 'for 64-bit integers' do
-        let :data do 0xFFFFFFFFFFFFFFFF end
+        let(:data) { 0xFFFFFFFFFFFFFFFF }
 
         it 'accepts qwords' do
           value[:type] = :qword
@@ -194,6 +194,7 @@ describe Puppet::Type.type(:registry_value) do
     end
 
     context 'binary data' do
+      # rubocop:disable RSpec/RepeatedExample
       ['', 'CA FE BE EF', 'DEADBEEF'].each do |data|
         it "should accept '#{data}'" do
           value[:type] = :binary
@@ -206,6 +207,7 @@ describe Puppet::Type.type(:registry_value) do
           value[:data] = data
         end
       end
+      # rubocop:enable RSpec/RepeatedExample
 
       ["\040\040", 'foobar', :true].each do |data|
         it "should reject '#{data}'" do

--- a/spec/watchr.rb
+++ b/spec/watchr.rb
@@ -11,7 +11,7 @@ def growl(message)
             (Regexp.last_match(1).to_i == 0) ? '~/.watchr_images/passed.png' : '~/.watchr_images/failed.png'
           else
             '~/.watchr_images/unknown.png'
-  end
+          end
   options = "-w -n Watchr --image '#{File.expand_path(image)}' -m '#{message}' '#{title}'"
   system %(#{growlnotify} #{options} &)
 end
@@ -70,8 +70,8 @@ Signal.trap 'INT' do
 end
 
 def file2spec(file)
-  result = file.sub('lib/puppet/', 'spec/unit/puppet/').gsub(%r{\.rb$}, '_spec.rb')
-  result = file.sub('lib/facter/', 'spec/unit/facter/').gsub(%r{\.rb$}, '_spec.rb')
+  _result = file.sub('lib/puppet/', 'spec/unit/puppet/').gsub(%r{\.rb$}, '_spec.rb')
+  _result = file.sub('lib/facter/', 'spec/unit/facter/').gsub(%r{\.rb$}, '_spec.rb')
 end
 
 watch('spec/.*_spec\.rb') do |_md|


### PR DESCRIPTION
PR add's support for Changelog Generator. PDK Sync had to be done manually due to unique code within the rakefile.