### PR TITLE
(IAC-967) Append null terminators since it is no longer part of the data

### DIFF
--- a/lib/puppet/provider/registry_value/registry.rb
+++ b/lib/puppet/provider/registry_value/registry.rb
@@ -178,16 +178,30 @@ Puppet::Type.type(:registry_value).provide(:registry) do
     raise error
   end
 
+  def wide_string_to_bytes(data)
+    bytes = Puppet::Util::Windows::String.wide_string(data).bytes.to_a
+    # versions prior to 7 embedded a wide null in the string content to work
+    # around ruby bugs, see PUP-3970
+    if Puppet::PUPPETVERSION[0].to_i >= 7
+      bytes << 0 << 0
+    else
+      bytes
+    end
+  end
+
+  # This method must include wide null terminators in the returned
+  # byte array for string-based registry values like REG_SZ. In
+  # addition REG_MULTI_SZ must append another wide null character
+  # to signify there are no more entries in the array.
   def data_to_bytes(type, data)
     bytes = []
 
     case type
     when Win32::Registry::REG_SZ, Win32::Registry::REG_EXPAND_SZ
-      bytes = Puppet::Util::Windows::String.wide_string(data).bytes.to_a
+      bytes = wide_string_to_bytes(data)
     when Win32::Registry::REG_MULTI_SZ
-      # each wide string is already NULL terminated
-      bytes = data.map { |s| Puppet::Util::Windows::String.wide_string(s).bytes.to_a }.flat_map { |a| a }
-      # requires an additional NULL terminator to terminate properly
+      bytes = data.map { |s| wide_string_to_bytes(s) }.flat_map { |a| a }
+      # requires an additional wide NULL terminator
       bytes << 0 << 0
     when Win32::Registry::REG_BINARY
       bytes = data.bytes.to_a
@@ -209,6 +223,8 @@ Puppet::Type.type(:registry_value).provide(:registry) do
       bytes = data_to_bytes(type, data)
       FFI::MemoryPointer.new(:uchar, bytes.length) do |data_ptr|
         data_ptr.write_array_of_uchar(bytes)
+        # From https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regsetvalueexw
+        # "cbData must include the size of the terminating null character or characters"
         if RegSetValueExW(reg.hkey, name_ptr, 0,
                           type, data_ptr, data_ptr.size) != 0
           raise Puppet::Util::Windows::Error, 'Failed to write registry value'


### PR DESCRIPTION
Early ruby versions did not handle wide terminators correctly and would sometime
read past the end of the string causing segfaults. To prevent that, puppet
started embedding a wide terminator within the string. So the ruby string 'hi'
would be encoded as the three character string 'hi\0', and then that would be
encoded as UTF-16LE.

While this works, it creates ambiguity as to whether the "\0" character is part
of the data or not. For example, "hi\n\0".chop is "hi\n" whereas "hi\n".chop is
"hi", and is probably what was intended.

Ruby has since fixed its wide terminator handling, and as of Puppet 7, the
`wide_string` method no longer embeds a terminator in the string. So update the
registry module to explicitly add the terminator(s) before calling
RegSetValueExW`.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-registry/blob/master/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=11482&summary=%5BREGISTRY%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MASTER branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
