### PR TITLE
Add possibility to produce a detailed error message 

### DIFF
--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -175,6 +175,15 @@ Puppet::Type.newtype(:registry_value) do
     end
   end
 
+  validate do
+    # To ensure consistent behavior, always require a value for the data
+    # property. This validation can be removed if we remove the default value
+    # for the data property, for all data types.
+    if property(:data).nil?
+      raise ArgumentError, "No value supplied for required property 'data'"
+    end
+  end
+
   # Autorequire the nearest ancestor registry_key found in the catalog.
   autorequire(:registry_key) do
     req = []

--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -94,7 +94,13 @@ Puppet::Type.newtype(:registry_value) do
     @doc = <<-EOT
       The data stored in the registry value.
     EOT
-    defaultto ''
+
+    # We probably shouldn't set default values for this property at all. For
+    # dword and qword specifically, the legacy default value will not pass
+    # validation. As such, no default value will be set for those types. At
+    # least for now, other types will still have the legacy empty-string
+    # default value.
+    defaultto { [:dword, :qword].include?(resource[:type]) ? nil : '' }
 
     validate do |value|
       case resource[:type]


### PR DESCRIPTION
Previously, the validation procedures were occuring in the #munge
method. This was a problem because if #munge raises an exception, the
error displayed to the user is opaque. If the data input is not valid,
the error should be raised in the #validate method. This will ensure
that the output given to the user includes information about the class,
resource, and parameter which is in error.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-registry/blob/main/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=11482&summary=%5BREGISTRY%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your Main branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
