### PR TITLE
(CONT-874) Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Changed
 
-- \(CONT-796\) Puppet 8 support [\#278](https://github.com/puppetlabs/puppetlabs-registry/pull/278) ([LukasAud](https://github.com/LukasAud))
+- \(CONT-796\) Puppet 8 support / Drop Puppet 6 support [\#278](https://github.com/puppetlabs/puppetlabs-registry/pull/278) ([LukasAud](https://github.com/LukasAud))
 
 ## [v4.1.2](https://github.com/puppetlabs/puppetlabs-registry/tree/v4.1.2) (2023-03-23)
 


### PR DESCRIPTION
Prior to this commit, it was brought to light an error in PR naming for Puppet 8 support related PRs, where they failed to mention the potential drop in Puppet 6 support. This commit aims to fix the changelog so that it reflects better the changes made in this major update.
