### PR TITLE
(MODULES-11424) Fix requirement method

### DIFF
--- a/lib/puppet/provider/registry_key/registry.rb
+++ b/lib/puppet/provider/registry_key/registry.rb
@@ -1,15 +1,7 @@
 # frozen_string_literal: true
 
-# REMIND: need to support recursive delete of subkeys & values
-begin
-  # We expect this to work once Puppet supports Rubygems in #7788
-  require 'puppet_x/puppetlabs/registry'
-rescue LoadError
-  # Work around #7788 (Rubygems support for modules)
-  require 'pathname' # JJM WORK_AROUND #14073
-  module_base = Pathname.new(__FILE__).dirname
-  require "#{module_base}../../../puppet_x/puppetlabs/registry"
-end
+require_relative '../../../puppet_x/puppetlabs/registry'
+
 # rubocop:disable Metrics/BlockLength
 Puppet::Type.type(:registry_key).provide(:registry) do
   desc <<-DOC

--- a/lib/puppet/provider/registry_value/registry.rb
+++ b/lib/puppet/provider/registry_value/registry.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
 require 'puppet/type'
-begin
-  require 'puppet_x/puppetlabs/registry'
-rescue LoadError
-  require 'pathname' # JJM WORK_AROUND #14073 and #7788
-  module_base = "#{Pathname.new(__FILE__).dirname}../../../"
-  require "#{module_base}puppet_x/puppetlabs/registry"
-end
+require_relative '../../../puppet_x/puppetlabs/registry'
 
 # rubocop:disable Metrics/BlockLength
 Puppet::Type.type(:registry_value).provide(:registry) do

--- a/lib/puppet/type/registry_key.rb
+++ b/lib/puppet/type/registry_key.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
 require 'puppet/type'
-begin
-  require 'puppet_x/puppetlabs/registry'
-rescue LoadError
-  require 'pathname' # JJM WORK_AROUND #14073 and #7788
-  require "#{Pathname.new(__FILE__).dirname}../../puppet_x/puppetlabs/registry"
-end
+require_relative '../../puppet_x/puppetlabs/registry'
 
 # @summary
 #   Manages registry keys on Windows systems

--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
 require 'puppet/type'
-begin
-  require 'puppet_x/puppetlabs/registry'
-rescue LoadError
-  require 'pathname' # JJM WORK_AROUND #14073 and #7788
-  require "#{Pathname.new(__FILE__).dirname}../../puppet_x/puppetlabs/registry"
-end
+require_relative '../../puppet_x/puppetlabs/registry'
 
 # @summary
 #   Manages registry values on Windows systems.


### PR DESCRIPTION
This is related to this PR : https://github.com/puppetlabs/puppetlabs-registry/pull/283

Having discussed this subject on puppet slack, it is recommended to use require_relative for this purpose.

# The problem
 require fails to find the path because of concatenation.

# The cause
This fix : https://github.com/puppetlabs/puppetlabs-registry/commit/2e11fe6798ecd8ea5d46ea133bb70cc71f2452da
The thing is "Pathname" override the behavior of the "+" sign to handle the missing "/" in the path ( https://ruby-doc.org/stdlib-2.6.3/libdoc/pathname/rdoc/Pathname.html#method-i-2B )

# The fix
As mentionned, it is recommended to use `require_relative`