### PR TITLE
(CAT-2389) Puppetcore update / Drop puppet 7 support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,6 @@ fixtures:
     provision: 'https://github.com/puppetlabs/provision.git'
     puppet_agent:
       repo: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-      ref:   v4.13.0
   symlinks:
     registry: "#{source_dir}"
     mixed_default_settings: "#{source_dir}/spec/fixtures/mixed_default_settings"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,6 @@ jobs:
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
+    with:
+      flags: "--latest-agent"
     secrets: "inherit"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,5 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      flags: "--latest-agent"
+      flags: "--nightly"
     secrets: "inherit"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,5 +13,7 @@ jobs:
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
+    with:
+      flags: "--nightly"
     secrets: "inherit"
 

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,1 +1,9 @@
+--fail-on-warnings
 --relative
+--no-80chars-check
+--no-140chars-check
+--no-class_inherits_from_params_class-check
+--no-autoloader_layout-check
+--no-documentation-check
+--no-single_quote_string_with_variables-check
+--ignore-paths=.vendor/**/*.pp,.bundle/**/*.pp,pkg/**/*.pp,spec/**/*.pp,tests/**/*.pp,types/**/*.pp,vendor/**/*.pp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 AllCops:
   NewCops: enable
   DisplayCopNames: true
-  TargetRubyVersion: '2.6'
+  TargetRubyVersion: 3.1
   Include:
   - "**/*.rb"
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -1,65 +1,86 @@
-source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+# frozen_string_literal: true
 
-def location_for(place_or_version, fake_version = nil)
-  git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
-  file_url_regex = %r{\Afile:\/\/(?<path>.*)}
+# For puppetcore, set GEM_SOURCE_PUPPETCORE = 'https://rubygems-puppetcore.puppet.com'
+gemsource_default = ENV['GEM_SOURCE'] || 'https://rubygems.org'
+gemsource_puppetcore = if ENV['PUPPET_FORGE_TOKEN']
+  'https://rubygems-puppetcore.puppet.com'
+else
+  ENV['GEM_SOURCE_PUPPETCORE'] || gemsource_default
+end
+source gemsource_default
 
-  if place_or_version && (git_url = place_or_version.match(git_url_regex))
-    [fake_version, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
-  elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
-    ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
+def location_for(place_or_constraint, fake_constraint = nil, opts = {})
+  git_url_regex  = /\A(?<url>(?:https?|git)[:@][^#]*)(?:#(?<branch>.*))?/
+  file_url_regex = %r{\Afile://(?<path>.*)}
+
+  if place_or_constraint && (git_url = place_or_constraint.match(git_url_regex))
+    # Git source → ignore :source, keep fake_constraint
+    [fake_constraint, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
+
+  elsif place_or_constraint && (file_url = place_or_constraint.match(file_url_regex))
+    # File source → ignore :source, keep fake_constraint or default >= 0
+    [fake_constraint || '>= 0', { path: File.expand_path(file_url[:path]), require: false }]
+
   else
-    [place_or_version, { require: false }]
+    # Plain version constraint → merge opts (including :source if provided)
+    [place_or_constraint, { require: false }.merge(opts)]
+  end
+end
+
+# Print debug information if DEBUG_GEMS or VERBOSE is set
+def print_gem_statement_for(gems)
+  puts 'DEBUG: Gem definitions that will be generated:'
+  gems.each do |gem_name, gem_params|
+    puts "DEBUG:   gem #{([gem_name.inspect] + gem_params.map(&:inspect)).join(', ')}"
   end
 end
 
 group :development do
-  gem "json", '= 2.1.0',                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.5.1',                         require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "deep_merge", '~> 1.2.2',                  require: false
   gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
-  gem "facterdb", '~> 2.1',                      require: false
+  gem "facterdb", '~> 2.1',                      require: false if Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "facterdb", '~> 3.0',                      require: false if Gem::Requirement.create(['>= 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "metadata-json-lint", '~> 4.0',            require: false
-  gem "rspec-puppet-facts", '~> 4.0',            require: false
+  gem "json-schema", '< 5.1.1',                  require: false
+  gem "rspec-puppet-facts", '~> 4.0',            require: false if Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "rspec-puppet-facts", '~> 5.0',            require: false if Gem::Requirement.create(['>= 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "dependency_checker", '~> 1.0.0',          require: false
   gem "parallel_tests", '= 3.12.1',              require: false
   gem "pry", '~> 0.10',                          require: false
   gem "simplecov-console", '~> 0.9',             require: false
-  gem "puppet-debugger", '~> 1.0',               require: false
+  gem "puppet-debugger", '~> 1.6',               require: false
   gem "rubocop", '~> 1.50.0',                    require: false
   gem "rubocop-performance", '= 1.16.0',         require: false
   gem "rubocop-rspec", '= 2.19.0',               require: false
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "rexml", '>= 3.3.9',                       require: false
+  gem "bigdecimal", '< 3.2.2',                   require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 group :development, :release_prep do
   gem "puppet-strings", '~> 4.0',         require: false
-  gem "puppetlabs_spec_helper", '~> 7.0', require: false
+  gem "puppetlabs_spec_helper", '~> 8.0', require: false
+  gem "puppet-blacksmith", '~> 7.0',      require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw]
+  gem "puppet_litmus", '~> 2.0',   require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
+  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw] if ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
   gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "serverspec", '~> 2.41',     require: false
 end
 
-puppet_version = ENV['PUPPET_GEM_VERSION']
-facter_version = ENV['FACTER_GEM_VERSION']
-hiera_version = ENV['HIERA_GEM_VERSION']
-
 gems = {}
+puppet_version = ENV.fetch('PUPPET_GEM_VERSION', nil)
+facter_version = ENV.fetch('FACTER_GEM_VERSION', nil)
+hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 
-gems['puppet'] = location_for(puppet_version)
+gems['puppet'] = location_for(puppet_version, nil, { source: gemsource_puppetcore })
+gems['facter'] = location_for(facter_version, nil, { source: gemsource_puppetcore })
+gems['hiera'] = location_for(hiera_version, nil, {}) if hiera_version
 
-# If facter or hiera versions have been specified via the environment
-# variables
-
-gems['facter'] = location_for(facter_version) if facter_version
-gems['hiera'] = location_for(hiera_version) if hiera_version
-
+# Generate the gem definitions
+print_gem_statement_for(gems) if ENV['DEBUG']
 gems.each do |gem_name, gem_params|
   gem gem_name, *gem_params
 end
@@ -67,12 +88,14 @@ end
 # Evaluate Gemfile.local and ~/.gemfile if they exist
 extra_gemfiles = [
   "#{__FILE__}.local",
-  File.join(Dir.home, '.gemfile'),
+  File.join(Dir.home, '.gemfile')
 ]
 
 extra_gemfiles.each do |gemfile|
-  if File.file?(gemfile) && File.readable?(gemfile)
-    eval(File.read(gemfile), binding)
-  end
+  next unless File.file?(gemfile) && File.readable?(gemfile)
+
+  # rubocop:disable Security/Eval
+  eval(File.read(gemfile), binding)
+  # rubocop:enable Security/Eval
 end
 # vim: syntax=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -7,3 +7,12 @@ require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet-strings/tasks' if Gem.loaded_specs.key? 'puppet-strings'
 
 PuppetLint.configuration.send('disable_relative')
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+PuppetLint.configuration.send('disable_autoloader_layout')
+PuppetLint.configuration.send('disable_documentation')
+PuppetLint.configuration.send('disable_single_quote_string_with_variables')
+PuppetLint.configuration.fail_on_warnings = true
+PuppetLint.configuration.ignore_paths = [".vendor/**/*.pp", ".bundle/**/*.pp", "pkg/**/*.pp", "spec/**/*.pp", "tests/**/*.pp", "types/**/*.pp", "vendor/**/*.pp"]
+

--- a/lib/puppet/type/registry_key.rb
+++ b/lib/puppet/type/registry_key.rb
@@ -116,7 +116,7 @@ Puppet::Type.newtype(:registry_key) do
     is_values.each do |is_value|
       unless should_values.include?(is_value.downcase)
         resource_path = PuppetX::Puppetlabs::Registry::RegistryValuePath.combine_path_and_value(self[:path], is_value)
-        resources << Puppet::Type.type(:registry_value).new(path: resource_path, ensure: :absent, catalog: catalog)
+        resources << Puppet::Type.type(:registry_value).new(path: resource_path, ensure: :absent, catalog:)
       end
     end
     resources

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ],
   "description": "This module provides a native type and provider to manage keys and values in the Windows Registry",

--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
     }
   ],
   "description": "This module provides a native type and provider to manage keys and values in the Windows Registry",
-  "pdk-version": "3.2.0",
+  "pdk-version": "3.5.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
-  "template-ref": "tags/3.2.0.4-0-g5d17ec1"
+  "template-ref": "heads/main-0-g19976cd"
 }

--- a/spec/defines/value_spec.rb
+++ b/spec/defines/value_spec.rb
@@ -54,13 +54,13 @@ RSpec.describe 'registry::value', type: :define do
         arr1 = ['dword', 'qword']
         arr1.each do |type|
           context "with #{type} numeric data" do
-            let(:params) { super().merge(type: type, data: 42) }
+            let(:params) { super().merge(type:, data: 42) }
 
             it { is_expected.to compile }
 
             it {
               expect(subject).to contain_registry_value('HKLM\Software\Vendor\\\\value_name')
-                .with(ensure: 'present', type: type, data: 42)
+                .with(ensure: 'present', type:, data: 42)
             }
           end
         end
@@ -79,13 +79,13 @@ RSpec.describe 'registry::value', type: :define do
         arr2 = ['string', 'expand']
         arr2.each do |type|
           context "with string data typed as '#{type}'" do
-            let(:params) { super().merge(type: type, data: 'some typed string data') }
+            let(:params) { super().merge(type:, data: 'some typed string data') }
 
             it { is_expected.to compile }
 
             it {
               expect(subject).to contain_registry_value('HKLM\Software\Vendor\\\\value_name')
-                .with(ensure: 'present', type: type, data: 'some typed string data')
+                .with(ensure: 'present', type:, data: 'some typed string data')
             }
           end
         end

--- a/spec/unit/puppet/provider/registry_key_spec.rb
+++ b/spec/unit/puppet/provider/registry_key_spec.rb
@@ -72,7 +72,7 @@ describe Puppet::Type.type(:registry_key).provider(:registry) do
       end
 
       it 'does not raise an error' do
-        reg_key = type.new(catalog: catalog,
+        reg_key = type.new(catalog:,
                            ensure: :absent,
                            name: "hklm\\#{reg_path}",
                            purge_values: true,
@@ -101,7 +101,7 @@ describe Puppet::Type.type(:registry_key).provider(:registry) do
       it 'does not use Rubys each_value, which unnecessarily string encodes' do
         # endash and tm undergo LOCALE conversion during Rubys each_value
         # which will generally lead to a conversion exception
-        reg_key = type.new(catalog: catalog,
+        reg_key = type.new(catalog:,
                            ensure: :absent,
                            name: "hklm\\#{reg_path}",
                            purge_values: true,

--- a/spec/unit/puppet/provider/registry_value_spec.rb
+++ b/spec/unit/puppet/provider/registry_value_spec.rb
@@ -78,7 +78,7 @@ describe Puppet::Type.type(:registry_value).provider(:registry) do
     end
 
     it 'returns false for a bogus hive/path' do
-      reg_value = type.new(path: 'hklm\foobar5000', catalog: catalog, provider: described_class.name)
+      reg_value = type.new(path: 'hklm\foobar5000', catalog:, provider: described_class.name)
       expect(reg_value.provider.exists?).to be(false)
     end
   end
@@ -109,9 +109,9 @@ describe Puppet::Type.type(:registry_value).provider(:registry) do
     let(:path) { "hklm\\#{puppet_key}\\#{subkey_name}\\#{valuename}" }
 
     def create_and_destroy(path, reg_type, data)
-      reg_value = type.new(path: path,
+      reg_value = type.new(path:,
                            type: reg_type,
-                           data: data,
+                           data:,
                            provider: described_class.name)
       already_exists = reg_value.provider.exists?
       expect(already_exists).to be(false)
@@ -224,13 +224,13 @@ describe Puppet::Type.type(:registry_value).provider(:registry) do
     let(:path) { "hklm\\#{puppet_key}\\#{subkey_name}\\#{SecureRandom.uuid}" }
 
     after(:each) do
-      reg_value = type.new(path: path, provider: described_class.name)
+      reg_value = type.new(path:, provider: described_class.name)
 
       reg_value.provider.destroy
     end
 
     def write_and_read_value(path, reg_type, value)
-      reg_value = type.new(path: path,
+      reg_value = type.new(path:,
                            type: reg_type,
                            data: value,
                            provider: described_class.name)

--- a/spec/unit/puppet/type/registry_key_spec.rb
+++ b/spec/unit/puppet/type/registry_key_spec.rb
@@ -10,7 +10,7 @@ describe Puppet::Type.type(:registry_key) do
 
   # This is overridden here so we get a consistent association with the key
   # and a catalog using memoized let methods.
-  let(:key) { Puppet::Type.type(:registry_key).new(name: 'HKLM\Software', catalog: catalog) }
+  let(:key) { Puppet::Type.type(:registry_key).new(name: 'HKLM\Software', catalog:) }
   let(:provider) { Puppet::Provider.new(key) }
 
   before(:each) do
@@ -86,14 +86,14 @@ describe Puppet::Type.type(:registry_key) do
 
       # This is overridden here so we get a consistent association with the key
       # and a catalog using memoized let methods.
-      let(:key) { Puppet::Type.type(:registry_key).new(name: 'HKLM\Software', catalog: catalog) }
+      let(:key) { Puppet::Type.type(:registry_key).new(name: 'HKLM\Software', catalog:) }
 
       before :each do
         key[:purge_values] = true
         catalog.add_resource(key)
-        catalog.add_resource(Puppet::Type.type(:registry_value).new(path: "#{key[:path]}\\val1", catalog: catalog))
-        catalog.add_resource(Puppet::Type.type(:registry_value).new(path: "#{key[:path]}\\vAl2", catalog: catalog))
-        catalog.add_resource(Puppet::Type.type(:registry_value).new(path: "#{key[:path]}\\\\val\\3", catalog: catalog))
+        catalog.add_resource(Puppet::Type.type(:registry_value).new(path: "#{key[:path]}\\val1", catalog:))
+        catalog.add_resource(Puppet::Type.type(:registry_value).new(path: "#{key[:path]}\\vAl2", catalog:))
+        catalog.add_resource(Puppet::Type.type(:registry_value).new(path: "#{key[:path]}\\\\val\\3", catalog:))
       end
 
       it "returns an empty array if the key doesn't have any values" do

--- a/spec/unit/puppet/type/registry_value_spec.rb
+++ b/spec/unit/puppet/type/registry_value_spec.rb
@@ -24,45 +24,45 @@ describe Puppet::Type.type(:registry_value) do
     # rubocop:disable RSpec/RepeatedExample
     ['hklm\\propname', 'hklm\\software\\propname'].each do |path|
       it "accepts #{path}" do
-        expect(described_class.new(path: path, catalog: catalog))
+        expect(described_class.new(path:, catalog:))
       end
     end
 
     ['hklm\\', 'hklm\\software\\', 'hklm\\software\\vendor\\'].each do |path|
       it "accepts the unnamed (default) value: #{path}" do
-        expect(described_class.new(path: path, catalog: catalog))
+        expect(described_class.new(path:, catalog:))
       end
     end
     # rubocop:enable RSpec/RepeatedExample
 
     it 'strips trailling slashes from unnamed values' do
-      value = described_class.new(path: 'hklm\\software\\\\', catalog: catalog)
+      value = described_class.new(path: 'hklm\\software\\\\', catalog:)
 
       expect(value[:path]).to eq('hklm\\software\\')
     end
 
     ['HKEY_DYN_DATA\\', 'HKEY_PERFORMANCE_DATA\\name'].each do |path|
       it "rejects #{path} as unsupported" do
-        expect { described_class.new(path: path, catalog: catalog) }.to raise_error(Puppet::Error, %r{Unsupported})
+        expect { described_class.new(path:, catalog:) }.to raise_error(Puppet::Error, %r{Unsupported})
       end
     end
 
     ['hklm', 'hkcr', 'unknown\\name', 'unknown\\subkey\\name'].each do |path|
       it "rejects #{path} as invalid" do
-        expect { described_class.new(path: path, catalog: catalog) }.to raise_error(Puppet::Error, %r{Invalid registry key})
+        expect { described_class.new(path:, catalog:) }.to raise_error(Puppet::Error, %r{Invalid registry key})
       end
     end
 
     ['HKLM\\name', 'HKEY_LOCAL_MACHINE\\name', 'hklm\\name'].each do |root|
       it "canonicalizes root key #{root}" do
-        value = described_class.new(path: root, catalog: catalog)
+        value = described_class.new(path: root, catalog:)
         expect(value[:path].should == 'hklm\name')
       end
     end
 
     ['HKLM\\Software\\\\nam\\e', 'HKEY_LOCAL_MACHINE\\Software\\\\nam\\e', 'hklm\\Software\\\\nam\\e'].each do |root|
       it "uses a double backslash when canonicalizing value names with a backslash #{root}" do
-        value = described_class.new(path: root, catalog: catalog)
+        value = described_class.new(path: root, catalog:)
         expect(value[:path].should == 'hklm\Software\\\\nam\e')
       end
     end
@@ -74,7 +74,7 @@ describe Puppet::Type.type(:registry_value) do
       'HKLM\\Software\\\\\\' => 'hklm\\Software\\\\\\' # A value name of backslash
     }.each do |testcase, expected_value|
       it "uses a double backslash as a delimeter between path and value for title #{testcase}" do
-        value = described_class.new(path: testcase, catalog: catalog)
+        value = described_class.new(path: testcase, catalog:)
         expect(value[:path].should == expected_value)
       end
     end
@@ -84,12 +84,12 @@ describe Puppet::Type.type(:registry_value) do
     it 'should be case-preserving'
     it 'should be case-insensitive'
     it 'supports 32-bit values' do
-      expect(_value = described_class.new(path: '32:hklm\software\foo', catalog: catalog))
+      expect(_value = described_class.new(path: '32:hklm\software\foo', catalog:))
     end
   end
 
   describe '#autorequire' do
-    let(:instance) { described_class.new(title: subject_title, catalog: catalog) }
+    let(:instance) { described_class.new(title: subject_title, catalog:) }
 
     [
       {
@@ -114,16 +114,16 @@ describe Puppet::Type.type(:registry_value) do
       },
     ].each do |testcase|
       context testcase[:context] do
-        let(:instance) { described_class.new(title: testcase[:reg_value_title], catalog: catalog) }
+        let(:instance) { described_class.new(title: testcase[:reg_value_title], catalog:) }
 
         it 'does not autorequire ancestor keys if none exist' do
           expect(instance.autorequire).to eq([])
         end
 
         it 'onlies autorequire the nearest ancestor registry_key resource' do
-          catalog.add_resource(Puppet::Type.type(:registry_key).new(path: 'hklm\Software', catalog: catalog))
-          catalog.add_resource(Puppet::Type.type(:registry_key).new(path: 'hklm\Software\foo', catalog: catalog))
-          catalog.add_resource(Puppet::Type.type(:registry_key).new(path: 'hklm\Software\foo\bar', catalog: catalog))
+          catalog.add_resource(Puppet::Type.type(:registry_key).new(path: 'hklm\Software', catalog:))
+          catalog.add_resource(Puppet::Type.type(:registry_key).new(path: 'hklm\Software\foo', catalog:))
+          catalog.add_resource(Puppet::Type.type(:registry_key).new(path: 'hklm\Software\foo\bar', catalog:))
 
           autorequire_array = instance.autorequire
           expect(autorequire_array.count).to eq(1)
@@ -134,7 +134,7 @@ describe Puppet::Type.type(:registry_value) do
   end
 
   describe 'type property' do
-    let(:value) { described_class.new(path: 'hklm\software\foo', catalog: catalog) }
+    let(:value) { described_class.new(path: 'hklm\software\foo', catalog:) }
 
     [:string, :array, :dword, :qword, :binary, :expand].each do |type|
       it "supports a #{type} type" do
@@ -149,7 +149,7 @@ describe Puppet::Type.type(:registry_value) do
   end
 
   describe 'data property' do
-    let(:value) { described_class.new(path: 'hklm\software\foo', catalog: catalog) }
+    let(:value) { described_class.new(path: 'hklm\software\foo', catalog:) }
 
     context 'with string data' do
       ['', 'foobar'].each do |data|


### PR DESCRIPTION
A set of changes dedicated to implementing puppetcore into our modules. This update, amongst other changes, removes Puppet 7 support.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
