### PR TITLE
Add support for Sensitive data in registry_value

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -164,11 +164,13 @@ Data type:
 Optional[Variant[
       String,
       Numeric,
-      Array[String]
+      Array[String],
+      Sensitive[String]
   ]]
 ```
 
-The data to place inside the registry value.
+The data to place inside the registry value. Can be a String, Numeric, Array[String],
+or Sensitive[String] for sensitive data like passwords.
 
 Default value: `undef`
 

--- a/examples/sensitive_example.pp
+++ b/examples/sensitive_example.pp
@@ -1,0 +1,26 @@
+# Example demonstrating Sensitive[String] support in registry::value
+# This example shows how to use Sensitive types for sensitive data like passwords
+
+# Create a sensitive password value
+$sensitive_password = Sensitive('mysecretpassword123')
+
+# Use the sensitive password in a registry value
+registry::value { 'DefaultPassword':
+  key  => 'HKLM\Software\MyApp',
+  data => $sensitive_password,
+  type => 'string',
+}
+
+# You can also use it directly inline
+registry::value { 'ApiKey':
+  key  => 'HKLM\Software\MyApp',
+  data => Sensitive('sk-1234567890abcdef'),
+  type => 'string',
+}
+
+# For array types, you can mix sensitive and non-sensitive values
+registry::value { 'MixedArray':
+  key  => 'HKLM\Software\MyApp',
+  data => ['public_value', Sensitive('secret_value'), 'another_public'],
+  type => 'array',
+} 

--- a/examples/sensitive_example.pp
+++ b/examples/sensitive_example.pp
@@ -23,4 +23,4 @@ registry::value { 'MixedArray':
   key  => 'HKLM\Software\MyApp',
   data => ['public_value', Sensitive('secret_value'), 'another_public'],
   type => 'array',
-} 
+}

--- a/examples/sensitive_example.pp
+++ b/examples/sensitive_example.pp
@@ -2,7 +2,7 @@
 # This example shows how to use Sensitive types for sensitive data like passwords
 
 # Create a sensitive password value
-$sensitive_password = Sensitive('mysecretpassword123')
+$sensitive_password = Sensitive('example-password')
 
 # Use the sensitive password in a registry value
 registry::value { 'DefaultPassword':
@@ -14,7 +14,7 @@ registry::value { 'DefaultPassword':
 # You can also use it directly inline
 registry::value { 'ApiKey':
   key  => 'HKLM\Software\MyApp',
-  data => Sensitive('sk-1234567890abcdef'),
+  data => Sensitive('EXAMPLE-API-KEY'),
   type => 'string',
 }
 

--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -108,7 +108,7 @@ Puppet::Type.newtype(:registry_value) do
         raise("The data must be a valid QWORD: received '#{value}'") unless munged && (munged.abs >> 64) <= 0
       when :binary
         munged = munge(value)
-        raise("The data must be a hex encoded string of the form: '00 01 02 ...': received '#{value}'") unless munged =~ %r{^([a-f\d]{2} ?)+$}i || value.empty?
+        raise("The data must be a hex encoded string of the form: '00 01 02 ...': received '#{value}'") unless munged =~ %r{^([a-f\d]{2} ?)+$}i || munged.to_s.empty?
       else # :string, :expand, :array
         true
       end

--- a/manifests/value.pp
+++ b/manifests/value.pp
@@ -17,7 +17,8 @@
 #   `puppet describe registry_value` for a list of supported types in the
 #   "type" parameter.
 # @param data
-#   The data to place inside the registry value.
+#   The data to place inside the registry value. Can be a String, Numeric, Array[String],
+#   or Sensitive[String] for sensitive data like passwords.
 #
 # Actions:
 #   - Manage the parent key if not already managed.
@@ -36,6 +37,15 @@
 #     }
 #   }
 #
+# @example This example shows how to use Sensitive types for sensitive data like passwords.
+#   class myapp {
+#     registry::value { 'DefaultPassword':
+#       key => 'HKLM\Software\MyApp',
+#       data => Sensitive('mysecretpassword123'),
+#       type => 'string',
+#     }
+#   }
+#
 define registry::value (
   Pattern[/^\w+/] $key,
   Optional[String] $value   = undef,
@@ -43,7 +53,8 @@ define registry::value (
   Optional[Variant[
       String,
       Numeric,
-      Array[String]
+      Array[String],
+      Sensitive[String]
   ]] $data                  = undef,
 ) {
   # ensure windows os

--- a/manifests/value.pp
+++ b/manifests/value.pp
@@ -41,7 +41,7 @@
 #   class myapp {
 #     registry::value { 'DefaultPassword':
 #       key => 'HKLM\Software\MyApp',
-#       data => Sensitive('mysecretpassword123'),
+#       data => Sensitive('example-password'),
 #       type => 'string',
 #     }
 #   }

--- a/spec/unit/puppet/type/registry_value_spec.rb
+++ b/spec/unit/puppet/type/registry_value_spec.rb
@@ -237,5 +237,31 @@ describe Puppet::Type.type(:registry_value) do
         end
       end
     end
+
+    context 'when sensitive data' do
+      it 'supports Sensitive[String] for string type' do
+        value[:type] = :string
+        sensitive_data = Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_password')
+        expect(value[:data] = sensitive_data)
+      end
+
+      it 'supports Sensitive[String] for expand type' do
+        value[:type] = :expand
+        sensitive_data = Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_path')
+        expect(value[:data] = sensitive_data)
+      end
+
+      it 'supports Sensitive[String] in array type' do
+        value[:type] = :array
+        sensitive_data = ['public_value', Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_value'), 'another_public']
+        expect(value[:data] = sensitive_data)
+      end
+
+      it 'supports Sensitive[String] for binary type' do
+        value[:type] = :binary
+        sensitive_data = Puppet::Pops::Types::PSensitiveType::Sensitive.new('CAFEBEEF')
+        expect(value[:data] = sensitive_data)
+      end
+    end
   end
 end

--- a/spec/unit/puppet/type/registry_value_spec.rb
+++ b/spec/unit/puppet/type/registry_value_spec.rb
@@ -242,25 +242,25 @@ describe Puppet::Type.type(:registry_value) do
       it 'supports Sensitive[String] for string type' do
         value[:type] = :string
         sensitive_data = Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_password')
-        expect(value[:data] = sensitive_data)
+        expect { value[:data] = sensitive_data }.not_to raise_error
       end
 
       it 'supports Sensitive[String] for expand type' do
         value[:type] = :expand
         sensitive_data = Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_path')
-        expect(value[:data] = sensitive_data)
+        expect { value[:data] = sensitive_data }.not_to raise_error
       end
 
       it 'supports Sensitive[String] in array type' do
         value[:type] = :array
         sensitive_data = ['public_value', Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_value'), 'another_public']
-        expect(value[:data] = sensitive_data)
+        expect { value[:data] = sensitive_data }.not_to raise_error
       end
 
       it 'supports Sensitive[String] for binary type' do
         value[:type] = :binary
         sensitive_data = Puppet::Pops::Types::PSensitiveType::Sensitive.new('CAFEBEEF')
-        expect(value[:data] = sensitive_data)
+        expect { value[:data] = sensitive_data }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
## Summary
In the case, that you want to store a credential in registry, the credential is shown in clear text in log / puppetboard.
This change adds the support for Sensitive data in the registry module. So credentials are now shown in the log anymore.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)