### PR TITLE
(PA-8354): Add support for Sensitive data in registry_value

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -164,11 +164,13 @@ Data type:
 Optional[Variant[
       String,
       Numeric,
-      Array[String]
+      Array[String],
+      Sensitive[String]
   ]]
 ```
 
-The data to place inside the registry value.
+The data to place inside the registry value. Can be a String, Numeric, Array[String],
+or Sensitive[String] for sensitive data like passwords.
 
 Default value: `undef`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -164,13 +164,14 @@ Data type:
 Optional[Variant[
       String,
       Numeric,
-      Array[String],
+      Array[Variant[String, Sensitive[String]]],
       Sensitive[String]
   ]]
 ```
 
-The data to place inside the registry value. Can be a String, Numeric, Array[String],
-or Sensitive[String] for sensitive data like passwords.
+The data to place inside the registry value. Can be a String, Numeric,
+Array[Variant[String, Sensitive[String]]], or Sensitive[String] for
+sensitive data like passwords.
 
 Default value: `undef`
 
@@ -260,4 +261,3 @@ The path to the registry value to manage.
 
 The specific backend to use for this `registry_value` resource. You will seldom need to specify this --- Puppet will
 usually discover the appropriate provider for your platform.
-

--- a/examples/sensitive_example.pp
+++ b/examples/sensitive_example.pp
@@ -1,0 +1,26 @@
+# Example demonstrating Sensitive[String] support in registry::value
+# This example shows how to use Sensitive types for sensitive data like passwords
+
+# Create a sensitive password value
+$sensitive_password = Sensitive('mysecretpassword123')
+
+# Use the sensitive password in a registry value
+registry::value { 'DefaultPassword':
+  key  => 'HKLM\Software\MyApp',
+  data => $sensitive_password,
+  type => 'string',
+}
+
+# You can also use it directly inline
+registry::value { 'ApiKey':
+  key  => 'HKLM\Software\MyApp',
+  data => Sensitive('sk-1234567890abcdef'),
+  type => 'string',
+}
+
+# For array types, you can mix sensitive and non-sensitive values
+registry::value { 'MixedArray':
+  key  => 'HKLM\Software\MyApp',
+  data => ['public_value', Sensitive('secret_value'), 'another_public'],
+  type => 'array',
+} 

--- a/examples/sensitive_example.pp
+++ b/examples/sensitive_example.pp
@@ -23,4 +23,4 @@ registry::value { 'MixedArray':
   key  => 'HKLM\Software\MyApp',
   data => ['public_value', Sensitive('secret_value'), 'another_public'],
   type => 'array',
-} 
+}

--- a/examples/sensitive_example.pp
+++ b/examples/sensitive_example.pp
@@ -2,7 +2,7 @@
 # This example shows how to use Sensitive types for sensitive data like passwords
 
 # Create a sensitive password value
-$sensitive_password = Sensitive('mysecretpassword123')
+$sensitive_password = Sensitive('example-password')
 
 # Use the sensitive password in a registry value
 registry::value { 'DefaultPassword':
@@ -14,7 +14,7 @@ registry::value { 'DefaultPassword':
 # You can also use it directly inline
 registry::value { 'ApiKey':
   key  => 'HKLM\Software\MyApp',
-  data => Sensitive('sk-1234567890abcdef'),
+  data => Sensitive('EXAMPLE-API-KEY'),
   type => 'string',
 }
 

--- a/lib/puppet/provider/registry_value/registry.rb
+++ b/lib/puppet/provider/registry_value/registry.rb
@@ -117,7 +117,6 @@ Puppet::Type.type(:registry_value).provide(:registry) do
     # array to something usable by the Win API.
     raise Puppet::Error, 'Data should be an Array (ErrorID 37D9BBAB-52E8-4A7C-9F2E-D7BF16A59050)' unless pdata.is_a?(Array)
 
-    # Unwrap Sensitive values if present
     unwrapped_data = pdata.map do |item|
       if item.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
         item.unwrap

--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -149,9 +149,11 @@ Puppet::Type.newtype(:registry_value) do
         munged = unwrap_sensitive(munge(value))
         raise("The data must be a valid QWORD: received '#{value}'") unless munged && (munged.abs >> 64) <= 0
       when :binary
+        unwrapped = unwrap_sensitive(value)
         munged = unwrap_sensitive(munge(value))
         valid_binary = munged.is_a?(String) && munged.match?(%r{^([a-f\d]{2} ?)+$}i)
-        raise("The data must be a hex encoded string of the form: '00 01 02 ...': received '#{value}'") unless valid_binary || munged.to_s.empty?
+        valid_empty = unwrapped.is_a?(String) && unwrapped.empty?
+        raise("The data must be a hex encoded string of the form: '00 01 02 ...': received '#{value}'") unless valid_binary || valid_empty
       else # :string, :expand, :array
         true
       end

--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -140,8 +140,9 @@ Puppet::Type.newtype(:registry_value) do
     validate do |value|
       case resource[:type]
       when :array
-        munged = unwrap_sensitive(munge(value))
-        raise('An array registry value can not contain empty values') if !munged.is_a?(Array) && munged.to_s.empty?
+        unwrapped = unwrap_sensitive(value)
+        raise('An array registry value can only contain string values') unless unwrapped.is_a?(String)
+        raise('An array registry value can not contain empty values') if unwrapped.empty?
       when :dword
         munged = unwrap_sensitive(munge(value))
         raise("The data must be a valid DWORD: received '#{value}'") unless munged && (munged.abs >> 32) <= 0
@@ -176,7 +177,7 @@ Puppet::Type.newtype(:registry_value) do
                             unwrapped_value
                           end
 
-                 # First, strip out all spaces from the string in the manfest.  Next,
+                 # First, strip out all spaces from the string in the manifest.  Next,
                  # put a space after each pair of hex digits.  Strip off the rightmost
                  # space if it's present.  Finally, downcase the whole thing.  The final
                  # result should be: "CaFE BEEF" => "ca fe be ef"

--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -192,6 +192,20 @@ Puppet::Type.newtype(:registry_value) do
       rewrap_sensitive(value, munged)
     end
 
+    # array_matching: :all makes Puppet::Property#insync? compare `is` and
+    # @should with a raw array equality check, bypassing property_matches?
+    # entirely. That breaks convergence for Sensitive-wrapped data, since
+    # Sensitive#== never matches the unwrapped value read back from the
+    # registry. Overriding insync? here to delegate to property_matches? per
+    # element restores the intended comparison semantics.
+    def insync?(is)
+      return true if @should.empty?
+      return false unless is.is_a?(Array)
+      return false unless is.length == @should.length
+
+      is.zip(@should).all? { |current, desired| property_matches?(current, desired) }
+    end
+
     def property_matches?(current, desired)
       if sensitive_value?(current) || sensitive_value?(desired)
         current = unwrap_sensitive(current)

--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -150,7 +150,8 @@ Puppet::Type.newtype(:registry_value) do
         raise("The data must be a valid QWORD: received '#{value}'") unless munged && (munged.abs >> 64) <= 0
       when :binary
         munged = unwrap_sensitive(munge(value))
-        raise("The data must be a hex encoded string of the form: '00 01 02 ...': received '#{value}'") unless munged =~ %r{^([a-f\d]{2} ?)+$}i || munged.to_s.empty?
+        valid_binary = munged.is_a?(String) && munged.match?(%r{^([a-f\d]{2} ?)+$}i)
+        raise("The data must be a hex encoded string of the form: '00 01 02 ...': received '#{value}'") unless valid_binary || munged.to_s.empty?
       else # :string, :expand, :array
         true
       end

--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -108,7 +108,7 @@ Puppet::Type.newtype(:registry_value) do
         raise("The data must be a valid QWORD: received '#{value}'") unless munged && (munged.abs >> 64) <= 0
       when :binary
         munged = munge(value)
-        raise("The data must be a hex encoded string of the form: '00 01 02 ...': received '#{value}'") unless munged =~ %r{^([a-f\d]{2} ?)+$}i || value.empty?
+        raise("The data must be a hex encoded string of the form: '00 01 02 ...': received '#{value}'") unless munged =~ %r{^([a-f\d]{2} ?)+$}i || munged.to_s.empty?
       else # :string, :expand, :array
         true
       end

--- a/lib/puppet/type/registry_value.rb
+++ b/lib/puppet/type/registry_value.rb
@@ -89,6 +89,47 @@ Puppet::Type.newtype(:registry_value) do
       The data stored in the registry value.
     DATA
 
+    def sensitive_value?(value)
+      value.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive) ||
+        (value.is_a?(Array) && value.any? { |item| sensitive_value?(item) })
+    end
+
+    def unwrap_sensitive(value)
+      case value
+      when Puppet::Pops::Types::PSensitiveType::Sensitive
+        unwrap_sensitive(value.unwrap)
+      when Array
+        value.map { |item| unwrap_sensitive(item) }
+      else
+        value
+      end
+    end
+
+    def rewrap_sensitive(original_value, munged_value)
+      case original_value
+      when Puppet::Pops::Types::PSensitiveType::Sensitive
+        Puppet::Pops::Types::PSensitiveType::Sensitive.new(munged_value)
+      when Array
+        munged_value.each_with_index.map do |item, index|
+          rewrap_sensitive(original_value[index], item)
+        end
+      else
+        munged_value
+      end
+    end
+
+    def redacted_value
+      Puppet::Pops::Types::PSensitiveType::Sensitive.new('redacted')
+    end
+
+    def normalize_comparable(value)
+      if resource[:type] != :array && value.is_a?(Array) && value.length == 1
+        value.first
+      else
+        value
+      end
+    end
+
     # We probably shouldn't set default values for this property at all. For
     # dword and qword specifically, the legacy default value will not pass
     # validation. As such, no default value will be set for those types. At
@@ -99,15 +140,16 @@ Puppet::Type.newtype(:registry_value) do
     validate do |value|
       case resource[:type]
       when :array
-        raise('An array registry value can not contain empty values') if value.empty?
+        munged = unwrap_sensitive(munge(value))
+        raise('An array registry value can not contain empty values') if !munged.is_a?(Array) && munged.to_s.empty?
       when :dword
-        munged = munge(value)
+        munged = unwrap_sensitive(munge(value))
         raise("The data must be a valid DWORD: received '#{value}'") unless munged && (munged.abs >> 32) <= 0
       when :qword
-        munged = munge(value)
+        munged = unwrap_sensitive(munge(value))
         raise("The data must be a valid QWORD: received '#{value}'") unless munged && (munged.abs >> 64) <= 0
       when :binary
-        munged = munge(value)
+        munged = unwrap_sensitive(munge(value))
         raise("The data must be a hex encoded string of the form: '00 01 02 ...': received '#{value}'") unless munged =~ %r{^([a-f\d]{2} ?)+$}i || munged.to_s.empty?
       else # :string, :expand, :array
         true
@@ -115,41 +157,46 @@ Puppet::Type.newtype(:registry_value) do
     end
 
     munge do |value|
-      # Unwrap Sensitive values if present
-      unwrapped_value = if value.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
-                          value.unwrap
-                        else
-                          value
-                        end
+      unwrapped_value = unwrap_sensitive(value)
 
-      case resource[:type]
-      when :dword, :qword
-        begin
-          Integer(unwrapped_value)
-        rescue StandardError
-          nil
-        end
-      when :binary
-        munged = if (unwrapped_value.respond_to?(:length) && unwrapped_value.length == 1) || (unwrapped_value.is_a?(Integer) && unwrapped_value <= 9)
-                   "0#{unwrapped_value}"
-                 else
-                   unwrapped_value
+      munged = case resource[:type]
+               when :dword, :qword
+                 begin
+                   Integer(unwrapped_value)
+                 rescue StandardError
+                   nil
                  end
+               when :binary
+                 munged = if (unwrapped_value.respond_to?(:length) && unwrapped_value.length == 1) || (unwrapped_value.is_a?(Integer) && unwrapped_value <= 9)
+                            "0#{unwrapped_value}"
+                          else
+                            unwrapped_value
+                          end
 
-        # First, strip out all spaces from the string in the manfest.  Next,
-        # put a space after each pair of hex digits.  Strip off the rightmost
-        # space if it's present.  Finally, downcase the whole thing.  The final
-        # result should be: "CaFE BEEF" => "ca fe be ef"
-        munged.gsub(%r{\s+}, '')
-              .gsub(%r{([0-9a-f]{2})}i) { "#{Regexp.last_match(1)} " }
-              .rstrip
-              .downcase
-      else # :string, :expand, :array
-        unwrapped_value
-      end
+                 # First, strip out all spaces from the string in the manfest.  Next,
+                 # put a space after each pair of hex digits.  Strip off the rightmost
+                 # space if it's present.  Finally, downcase the whole thing.  The final
+                 # result should be: "CaFE BEEF" => "ca fe be ef"
+                 munged.gsub(%r{\s+}, '')
+                       .gsub(%r{([0-9a-f]{2})}i) { "#{Regexp.last_match(1)} " }
+                       .rstrip
+                       .downcase
+               else # :string, :expand, :array
+                 unwrapped_value
+               end
+
+      rewrap_sensitive(value, munged)
     end
 
     def property_matches?(current, desired)
+      if sensitive_value?(current) || sensitive_value?(desired)
+        current = unwrap_sensitive(current)
+        desired = unwrap_sensitive(desired)
+      end
+
+      current = normalize_comparable(current)
+      desired = normalize_comparable(desired)
+
       case resource[:type]
       when :binary
         return false unless current
@@ -161,6 +208,11 @@ Puppet::Type.newtype(:registry_value) do
     end
 
     def change_to_s(currentvalue, newvalue)
+      if sensitive_value?(currentvalue) || sensitive_value?(newvalue)
+        currentvalue = redacted_value
+        newvalue = redacted_value
+      end
+
       currentvalue = currentvalue.join(',') if currentvalue.respond_to? :join
       newvalue = newvalue.join(',') if newvalue.respond_to? :join
       super(currentvalue, newvalue)

--- a/manifests/value.pp
+++ b/manifests/value.pp
@@ -17,7 +17,8 @@
 #   `puppet describe registry_value` for a list of supported types in the
 #   "type" parameter.
 # @param data
-#   The data to place inside the registry value.
+#   The data to place inside the registry value. Can be a String, Numeric, Array[String],
+#   or Sensitive[String] for sensitive data like passwords.
 #
 # Actions:
 #   - Manage the parent key if not already managed.
@@ -36,6 +37,15 @@
 #     }
 #   }
 #
+# @example This example shows how to use Sensitive types for sensitive data like passwords.
+#   class myapp {
+#     registry::value { 'DefaultPassword':
+#       key => 'HKLM\Software\MyApp',
+#       data => Sensitive('mysecretpassword123'),
+#       type => 'string',
+#     }
+#   }
+#
 define registry::value (
   Pattern[/^\w+/] $key,
   Optional[String] $value   = undef,
@@ -43,7 +53,8 @@ define registry::value (
   Optional[Variant[
       String,
       Numeric,
-      Array[String]
+      Array[String],
+      Sensitive[String]
   ]] $data                  = undef,
 ) {
   # ensure windows os

--- a/manifests/value.pp
+++ b/manifests/value.pp
@@ -17,8 +17,9 @@
 #   `puppet describe registry_value` for a list of supported types in the
 #   "type" parameter.
 # @param data
-#   The data to place inside the registry value. Can be a String, Numeric, Array[String],
-#   or Sensitive[String] for sensitive data like passwords.
+#   The data to place inside the registry value. Can be a String, Numeric,
+#   Array[Variant[String, Sensitive[String]]], or Sensitive[String] for
+#   sensitive data like passwords.
 #
 # Actions:
 #   - Manage the parent key if not already managed.
@@ -53,7 +54,7 @@ define registry::value (
   Optional[Variant[
       String,
       Numeric,
-      Array[String],
+      Array[Variant[String, Sensitive[String]]],
       Sensitive[String]
   ]] $data                  = undef,
 ) {

--- a/manifests/value.pp
+++ b/manifests/value.pp
@@ -41,7 +41,7 @@
 #   class myapp {
 #     registry::value { 'DefaultPassword':
 #       key => 'HKLM\Software\MyApp',
-#       data => Sensitive('mysecretpassword123'),
+#       data => Sensitive('example-password'),
 #       type => 'string',
 #     }
 #   }

--- a/spec/defines/value_spec.rb
+++ b/spec/defines/value_spec.rb
@@ -101,6 +101,17 @@ RSpec.describe 'registry::value', type: :define do
           }
         end
 
+        context 'with array data containing sensitive elements' do
+          let(:params) do
+            super().merge(
+              type: 'array',
+              data: ['public_value', sensitive('secret_value')],
+            )
+          end
+
+          it { is_expected.to compile }
+        end
+
         context 'with an empty value name' do
           let(:params) { super().merge(value: '(default)') }
 

--- a/spec/unit/puppet/type/registry_value_spec.rb
+++ b/spec/unit/puppet/type/registry_value_spec.rb
@@ -237,5 +237,31 @@ describe Puppet::Type.type(:registry_value) do
         end
       end
     end
+
+    context 'when sensitive data' do
+      it 'supports Sensitive[String] for string type' do
+        value[:type] = :string
+        sensitive_data = Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_password')
+        expect(value[:data] = sensitive_data)
+      end
+
+      it 'supports Sensitive[String] for expand type' do
+        value[:type] = :expand
+        sensitive_data = Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_path')
+        expect(value[:data] = sensitive_data)
+      end
+
+      it 'supports Sensitive[String] in array type' do
+        value[:type] = :array
+        sensitive_data = ['public_value', Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_value'), 'another_public']
+        expect(value[:data] = sensitive_data)
+      end
+
+      it 'supports Sensitive[String] for binary type' do
+        value[:type] = :binary
+        sensitive_data = Puppet::Pops::Types::PSensitiveType::Sensitive.new('CAFEBEEF')
+        expect(value[:data] = sensitive_data)
+      end
+    end
   end
 end

--- a/spec/unit/puppet/type/registry_value_spec.rb
+++ b/spec/unit/puppet/type/registry_value_spec.rb
@@ -243,24 +243,41 @@ describe Puppet::Type.type(:registry_value) do
         value[:type] = :string
         sensitive_data = Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_password')
         expect { value[:data] = sensitive_data }.not_to raise_error
+        expect(value[:data].first).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+        expect(value[:data].first.unwrap).to eq('secret_password')
       end
 
       it 'supports Sensitive[String] for expand type' do
         value[:type] = :expand
         sensitive_data = Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_path')
         expect { value[:data] = sensitive_data }.not_to raise_error
+        expect(value[:data].first).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+        expect(value[:data].first.unwrap).to eq('secret_path')
       end
 
       it 'supports Sensitive[String] in array type' do
         value[:type] = :array
         sensitive_data = ['public_value', Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_value'), 'another_public']
         expect { value[:data] = sensitive_data }.not_to raise_error
+        expect(value[:data][0]).to eq('public_value')
+        expect(value[:data][1]).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+        expect(value[:data][1].unwrap).to eq('secret_value')
+        expect(value[:data][2]).to eq('another_public')
       end
 
       it 'supports Sensitive[String] for binary type' do
         value[:type] = :binary
         sensitive_data = Puppet::Pops::Types::PSensitiveType::Sensitive.new('CAFEBEEF')
         expect { value[:data] = sensitive_data }.not_to raise_error
+        expect(value[:data].first).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+        expect(value[:data].first.unwrap).to eq('ca fe be ef')
+      end
+
+      it 'matches current values against sensitive desired values without unwrapping stored data' do
+        value[:type] = :array
+        value[:data] = ['public_value', Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_value')]
+
+        expect(value.property(:data).property_matches?(['public_value', 'secret_value'], value[:data])).to be(true)
       end
     end
   end

--- a/spec/unit/puppet/type/registry_value_spec.rb
+++ b/spec/unit/puppet/type/registry_value_spec.rb
@@ -242,25 +242,25 @@ describe Puppet::Type.type(:registry_value) do
       it 'supports Sensitive[String] for string type' do
         value[:type] = :string
         sensitive_data = Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_password')
-        expect(value[:data] = sensitive_data)
+        expect { value[:data] = sensitive_data }.not_to raise_error
       end
 
       it 'supports Sensitive[String] for expand type' do
         value[:type] = :expand
         sensitive_data = Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_path')
-        expect(value[:data] = sensitive_data)
+        expect { value[:data] = sensitive_data }.not_to raise_error
       end
 
       it 'supports Sensitive[String] in array type' do
         value[:type] = :array
         sensitive_data = ['public_value', Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_value'), 'another_public']
-        expect(value[:data] = sensitive_data)
+        expect { value[:data] = sensitive_data }.not_to raise_error
       end
 
       it 'supports Sensitive[String] for binary type' do
         value[:type] = :binary
         sensitive_data = Puppet::Pops::Types::PSensitiveType::Sensitive.new('CAFEBEEF')
-        expect(value[:data] = sensitive_data)
+        expect { value[:data] = sensitive_data }.not_to raise_error
       end
     end
   end

--- a/spec/unit/puppet/type/registry_value_spec.rb
+++ b/spec/unit/puppet/type/registry_value_spec.rb
@@ -286,6 +286,53 @@ describe Puppet::Type.type(:registry_value) do
 
         expect(value.property(:data).property_matches?(['public_value', 'secret_value'], value[:data])).to be(true)
       end
+
+      # array_matching: :all makes Puppet::Property#insync? do a raw is == @should
+      # comparison, which never calls property_matches?. These tests go through
+      # insync? itself (as a real Puppet run would) rather than calling
+      # property_matches? directly, so they catch a regression where Sensitive-wrapped
+      # data never converges.
+      context 'convergence via insync?' do
+        it 'is in sync when the registry already holds the unwrapped string value' do
+          value[:type] = :string
+          value[:data] = Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_password')
+
+          expect(value.property(:data).insync?(['secret_password'])).to be(true)
+        end
+
+        it 'is out of sync when the registry holds a different string value' do
+          value[:type] = :string
+          value[:data] = Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_password')
+
+          expect(value.property(:data).insync?(['other_password'])).to be(false)
+        end
+
+        it 'is in sync when the registry already holds the unwrapped array values' do
+          value[:type] = :array
+          value[:data] = ['public_value', Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_value')]
+
+          expect(value.property(:data).insync?(['public_value', 'secret_value'])).to be(true)
+        end
+
+        it 'is out of sync when a sensitive array element differs from the registry' do
+          value[:type] = :array
+          value[:data] = ['public_value', Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_value')]
+
+          expect(value.property(:data).insync?(['public_value', 'other_value'])).to be(false)
+        end
+
+        it 'stays in sync across two successive applies (idempotency)' do
+          value[:type] = :string
+          value[:data] = Puppet::Pops::Types::PSensitiveType::Sensitive.new('secret_password')
+          data_property = value.property(:data)
+
+          first_run_in_sync = data_property.insync?(['secret_password'])
+          second_run_in_sync = data_property.insync?(['secret_password'])
+
+          expect(first_run_in_sync).to be(true)
+          expect(second_run_in_sync).to be(true)
+        end
+      end
     end
   end
 end

--- a/spec/unit/puppet/type/registry_value_spec.rb
+++ b/spec/unit/puppet/type/registry_value_spec.rb
@@ -236,6 +236,13 @@ describe Puppet::Type.type(:registry_value) do
           expect { value[:data] = data }.to raise_error(Puppet::Error)
         end
       end
+
+      [[true], [0], [['nested']], ['foo', true, 'bar'], ['foo', 0, 'bar']].each do |data|
+        it "rejects non-string element in '#{data}'" do
+          value[:type] = :array
+          expect { value[:data] = data }.to raise_error(Puppet::Error, %r{can only contain string values})
+        end
+      end
     end
 
     context 'when sensitive data' do


### PR DESCRIPTION
- Updated REFERENCE.md to include Sensitive[String] in the data type options.
- Enhanced registry_value provider to unwrap Sensitive values before processing.
- Modified registry_value type to handle Sensitive data during value munging.
- Updated value.pp documentation to demonstrate usage of Sensitive types.
- Added unit tests to verify support for Sensitive data across different types.

PR created to run acceptance test against PR #316 